### PR TITLE
Add ability to import from openScale backup

### DIFF
--- a/app/lib/core/measurement.dart
+++ b/app/lib/core/measurement.dart
@@ -82,7 +82,6 @@ class Measurement {
     => '${date.toIso8601String()} ${weight.toStringAsFixed(10)}';
 
   /// copy with applying change
-  
   static Measurement fromString({required String exportString, bool native=true}) {
     if(native){
       // trale format

--- a/app/lib/core/measurement.dart
+++ b/app/lib/core/measurement.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:hive/hive.dart';
+import 'package:intl/intl.dart';
 import 'package:provider/provider.dart';
 
 import 'package:trale/core/traleNotifier.dart';
@@ -81,18 +82,40 @@ class Measurement {
     => '${date.toIso8601String()} ${weight.toStringAsFixed(10)}';
 
   /// copy with applying change
-  static Measurement fromString({required String exportString}) {
-    final List<String> strings = exportString.split(' ');
+  
+  static Measurement fromString({required String exportString, bool native=true}) {
+    if(native){
+      // trale format
+      final List<String> strings = exportString.split(' ');
 
-    if (strings.length != 2) {
-      print('error with parsing measurement!');
+      if(strings.length != 2){
+        print('error with parsing measurement (trale format)!');
+      }
+
+      return Measurement(
+        weight: double.parse(strings[1]),
+        date: DateTime.parse(strings[0]),
+        isMeasured: true,
+      );
+    } else {
+      // openscale format
+      final List<String> strings = exportString.split(',');
+      
+      if(strings.length != 19){
+        print('error with parsing measurement (openscale format)!');
+      }
+
+      final String dateString = strings[8].substring(1, strings[8].length-2);
+      final DateFormat format = DateFormat('yyyy-MM-dd HH:mm');
+      final DateTime date = format.parse(dateString);
+
+      
+      return Measurement(
+        weight: double.parse(strings[18]),
+        date: DateTime.parse(date.toIso8601String()),
+        isMeasured: true,
+      );
     }
-
-    return Measurement(
-      weight: double.parse(strings[1]),
-      date: DateTime.parse(strings[0]),
-      isMeasured: true,
-    );
   }
 
   /// compare method to use default sort method on list

--- a/app/lib/l10n/app_de.arb
+++ b/app/lib/l10n/app_de.arb
@@ -37,7 +37,7 @@
     "home": "Start",
     "import": "Importiere Backup",
     "importDialog": "Importiere alle Messungen in die aktuelle Messreihe. Dies kann nicht rückgängig gemacht werden!",
-    "importSubtitle": "Importiere Messungen aus einer Backup .txt Datei.",
+    "importSubtitle": "Importiere Messungen aus einer Backup .txt Datei oder einer openScale .csv Datei.",
     "importingAbort": "Import abgebrochen.",
     "interpolation": "Interpolation",
     "intro1": "drücke",

--- a/app/lib/l10n/app_en.arb
+++ b/app/lib/l10n/app_en.arb
@@ -104,9 +104,9 @@
     "@import": {
         "description": "Import backup."
     },
-    "importSubtitle": "Import measurements from txt backup file.",
+    "importSubtitle": "Import measurements from txt backup file or openScale csv file.",
     "@importSubtitle": {
-        "description": "Import measurements from txt backup file."
+        "description": "Import measurements from txt backup file or openScale csv file."
     },
     "amoled": "AMOLED",
     "@amoled": {

--- a/app/lib/pages/settings.dart
+++ b/app/lib/pages/settings.dart
@@ -226,7 +226,7 @@ class ImportListTile extends StatelessWidget {
           if (accepted) {
             final FilePickerResult? pickerResult = await FilePicker.platform.pickFiles(
               type: FileType.custom,
-              allowedExtensions: <String>['txt'],
+              allowedExtensions: <String>['txt','csv'],
             );
             if (
               pickerResult != null &&
@@ -236,9 +236,10 @@ class ImportListTile extends StatelessWidget {
               int measurementCounts = 0;
               for (final String line in file.readAsLinesSync()) {
                 // parse comments
-                if (!line.startsWith('#')) {
+                if (!line.startsWith('#') && !line.startsWith('"')) {
                   final Measurement m = Measurement.fromString(
-                    exportString: line
+                    exportString: line,
+                    native: pickerResult.files.single.extension == 'txt',
                   );
                   final bool wasInserted = db.insertMeasurement(m);
                   if (wasInserted) {


### PR DESCRIPTION
Just stumbled upon trale, love the design!

I use [openScale](https://github.com/oliexdev/openScale) to pull measurements from a bluetooth scale, and I'd love to be able to take that data into trale.

openScale offers `.csv` backups (although this is somewhat hidden, the `.csv` files are only created using the "auto backup" feature, not the manual backup). I've attached an 
[example](https://github.com/QuantumPhysique/trale/files/13957044/openScale.export.csv) for reference.

This PR adds support for this format to trale, differentiating the formats by their respective extensions (`txt` and `csv`). The openScale format parsing is naive, it doesnt reference the included headers but just targets the specific fields, so if this format changes, the logic here will likely break.

If there's interest, I can implement proper `csv` parsing logic, for now this approach works well for the latest openScale version.

Would love to see this get merged so I don't need to maintain my fork to use upstream updates! Let me know if any changes are needed or there are problems with this.