### PR TITLE
Add high contrast mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ### Added Features and Improvements 🙌:
 - Use predictive back gesture
 - Incorporate user height to calculate BMI-based minimum target weight, replacing the predefined value.
+- Added experimental high contrast mode
 
 ### Bugfix 🐛:
 - Fix system color scheme for monochrome colors, #236

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,8 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Bugfix 🐛:
 - Fix system color scheme for monochrome colors, #236
+- Fix using wrong font color in some places
+
 
 ## [0.10.1] - 2025-03-03
 ### Bugfix 🐛:

--- a/app/lib/core/contrast.dart
+++ b/app/lib/core/contrast.dart
@@ -1,0 +1,57 @@
+/// Enum with all available contrast levels
+enum ContrastLevel {
+  /// none
+  normal,
+  /// 1
+  one,
+  /// 2
+  two,
+  /// 3
+  three,
+  /// 4
+  four,
+  /// 5
+  five,
+}
+
+/// extend contrast level
+extension ContrastLevelExtension on ContrastLevel {
+  /// get the interpolation strength of measurements [days]
+  double get contrast => <ContrastLevel, double>{
+      ContrastLevel.normal: 0,
+      ContrastLevel.one: 0.1,
+      ContrastLevel.two: 0.2,
+      ContrastLevel.three: 0.3,
+      ContrastLevel.four: 0.4,
+      ContrastLevel.five: 0.5,
+    }[this]!;
+
+  /// get international name
+  String get nameLong => (contrast * 10).round().toString();
+
+  /// get string expression
+  String get name => toString().split('.').last;
+
+  /// get index
+  int get idx {
+    for (int i=0; i<ContrastLevel.values.length; i++) {
+      if (ContrastLevel.values[i] == this) {
+        return i;
+      }
+    }
+    return -1;
+  }
+}
+
+/// convert string to interpolation strength
+extension ContrastLevelParsing on String {
+  /// convert string to interpolation strength
+  ContrastLevel? toContrastLevel() {
+    for (final ContrastLevel lvl in ContrastLevel.values) {
+      if (this == lvl.name) {
+        return lvl;
+    }
+      }
+    return null;
+  }
+}

--- a/app/lib/core/preferences.dart
+++ b/app/lib/core/preferences.dart
@@ -1,7 +1,7 @@
 import 'package:shared_preferences/shared_preferences.dart';
 import 'package:trale/core/backupInterval.dart';
+import 'package:trale/core/contrast.dart';
 import 'package:trale/core/firstDay.dart';
-
 import 'package:trale/core/interpolation.dart';
 import 'package:trale/core/language.dart';
 import 'package:trale/core/printFormat.dart';
@@ -62,6 +62,9 @@ class Preferences {
 
   /// default for theme
   final String defaultTheme = TraleCustomTheme.water.name;
+
+  /// default for contrast level
+  final ContrastLevel defaultContrastLevel = ContrastLevel.normal;
 
   /// default unit
   final TraleUnit defaultUnit = TraleUnit.kg;
@@ -154,6 +157,16 @@ class Preferences {
 
   /// set theme mode
   set theme(String theme) => prefs.setString('theme', theme);
+
+  /// get contrast level
+  ContrastLevel get contrastLevel => prefs.getString('contrastLevel')!
+    .toContrastLevel()!;
+
+  /// set contrast level
+  set contrastLevel(ContrastLevel level) => prefs.setString(
+      'contrastLevel',
+      level.name,
+    );
 
   /// get unit mode
   TraleUnit get unit => prefs.getString('unit')!.toTraleUnit()!;
@@ -259,6 +272,9 @@ class Preferences {
     }
     if (override || !prefs.containsKey('theme')) {
       theme = defaultTheme;
+    }
+    if (override || !prefs.containsKey('contrastLevel')) {
+      contrastLevel = defaultContrastLevel;
     }
     if (override || !prefs.containsKey('unit')) {
       unit = defaultUnit;

--- a/app/lib/core/theme.dart
+++ b/app/lib/core/theme.dart
@@ -5,6 +5,7 @@ import 'package:dynamic_color/dynamic_color.dart';
 import 'package:flutter/material.dart';
 import 'package:phosphor_flutter/phosphor_flutter.dart';
 import 'package:provider/provider.dart';
+import 'package:trale/core/contrast.dart';
 
 import 'package:trale/core/traleNotifier.dart';
 import 'package:trale/l10n-gen/app_localizations.dart';
@@ -62,6 +63,7 @@ class TraleTheme {
     required this.seedColor,
     required this.brightness,
     this.isAmoled=false,
+    this.contrast=0.0,
   });
 
   /// copyWith constructor
@@ -69,11 +71,13 @@ class TraleTheme {
     Brightness? brightness,
     Color? seedColor,
     bool? isAmoled,
+    double? contrast,
   }) {
     return TraleTheme(
       brightness: brightness ?? this.brightness,
       seedColor: seedColor ?? this.seedColor,
       isAmoled: isAmoled ?? this.isAmoled,
+      contrast: contrast ?? this.contrast,
     );
   }
 
@@ -100,6 +104,8 @@ class TraleTheme {
   final double padding = 16;
   /// if true make background true black
   late bool isAmoled;
+  /// contrast level
+  late double contrast;
   /// Get border radius
   double get borderRadius => 16;
 
@@ -166,6 +172,7 @@ class TraleTheme {
     ColorScheme colorScheme = ColorScheme.fromSeed(
       seedColor: seedColor,
       brightness: brightness,
+      contrastLevel: contrast,
       dynamicSchemeVariant: isGrey
         ? DynamicSchemeVariant.fidelity
         : DynamicSchemeVariant.tonalSpot,
@@ -257,14 +264,22 @@ extension TraleCustomThemeExtension on TraleCustomTheme {
     TraleCustomTheme.plum: const Color(0xff8e4585),
   }[this]!;
 
+  /// get contrast level
+  double contrast(BuildContext context) =>
+    Provider.of<TraleNotifier>(context, listen: false).contrastLevel.contrast;
+
   /// get corresponding light theme
   TraleTheme light(BuildContext context) => TraleTheme(
-    seedColor: seedColor(context), brightness: Brightness.light,
+    seedColor: seedColor(context),
+    brightness: Brightness.light,
+    contrast: contrast(context),
   );
 
   /// get corresponding light theme
   TraleTheme dark(BuildContext context) => TraleTheme(
-    seedColor: seedColor(context), brightness: Brightness.dark,
+    seedColor: seedColor(context),
+    brightness: Brightness.dark,
+    contrast: contrast(context),
   );
 
   /// get amoled dark theme

--- a/app/lib/core/theme.dart
+++ b/app/lib/core/theme.dart
@@ -371,3 +371,16 @@ class TraleThemeExtension extends ThemeExtension<TraleThemeExtension> {
     );
   }
 }
+
+/// extension of theme
+extension ColorTextThemeExtension on TextStyle {
+  TextStyle onSecondaryContainer(BuildContext context) => copyWith(
+    color: Theme.of(context).colorScheme.onSecondaryContainer,
+  );
+  TextStyle onSurface(BuildContext context) => copyWith(
+    color: Theme.of(context).colorScheme.onSurface,
+  );
+  TextStyle onSurfaceVariant(BuildContext context) => copyWith(
+    color: Theme.of(context).colorScheme.onSurfaceVariant,
+  );
+}

--- a/app/lib/core/traleNotifier.dart
+++ b/app/lib/core/traleNotifier.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:intl/date_time_patterns.dart';
 import 'package:intl/intl.dart';
 import 'package:trale/core/backupInterval.dart';
+import 'package:trale/core/contrast.dart';
 import 'package:trale/core/firstDay.dart';
 import 'package:trale/core/interpolation.dart';
 import 'package:trale/core/language.dart';
@@ -30,6 +31,17 @@ class TraleNotifier with ChangeNotifier {
   set themeMode(ThemeMode mode) {
     if (mode != themeMode) {
       prefs.nightMode = mode.toCustomString();
+      notifyListeners();
+    }
+  }
+
+  /// get contrast level
+  ContrastLevel get contrastLevel => prefs.contrastLevel;
+
+  /// set contrast level
+  set contrastLevel(ContrastLevel level) {
+    if (level != contrastLevel) {
+      prefs.contrastLevel = level;
       notifyListeners();
     }
   }

--- a/app/lib/l10n/app_en.arb
+++ b/app/lib/l10n/app_en.arb
@@ -481,5 +481,9 @@
   "firstDay": "First day",
   "@firstDay": {
     "description": "First displayed day of the week"
+  },
+  "highContrast": "High contrast",
+  "@highContrast": {
+    "description": "High contrast mode label (accessibility setting)."
   }
 }

--- a/app/lib/pages/settings.dart
+++ b/app/lib/pages/settings.dart
@@ -3,6 +3,7 @@ import 'package:flutter/material.dart';
 import 'package:phosphor_flutter/phosphor_flutter.dart';
 import 'package:provider/provider.dart';
 import 'package:trale/core/backupInterval.dart';
+import 'package:trale/core/contrast.dart';
 import 'package:trale/core/firstDay.dart';
 import 'package:trale/core/icons.dart';
 import 'package:trale/core/interpolation.dart';
@@ -409,6 +410,50 @@ class DarkModeListTile extends StatelessWidget {
     );
   }
 }
+
+
+/// ListTile for changing interpolation settings
+class ContrastLevelSetting extends StatelessWidget {
+  /// constructor
+  const ContrastLevelSetting({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      padding: EdgeInsets.fromLTRB(
+        2 * TraleTheme.of(context)!.padding,
+        0.5 * TraleTheme.of(context)!.padding,
+        TraleTheme.of(context)!.padding,
+        0.5 * TraleTheme.of(context)!.padding,
+      ),
+
+      child: Row(
+        mainAxisAlignment: MainAxisAlignment.spaceBetween,
+        children: <Widget>[
+          AutoSizeText(
+            AppLocalizations.of(context)!.highContrast.inCaps,
+            style: Theme.of(context).textTheme.bodyLarge,
+            maxLines: 1,
+          ),
+          Slider(
+            value: Provider.of<TraleNotifier>(context)
+                .contrastLevel.idx.toDouble(),
+            divisions: ContrastLevel.values.length - 1,
+            min: 0.0,
+            max: ContrastLevel.values.length.toDouble() - 1,
+            label: Provider.of<TraleNotifier>(context).contrastLevel.nameLong,
+            onChanged: (double newContrastLevel) async {
+              Provider.of<TraleNotifier>(
+                  context, listen: false
+              ).contrastLevel = ContrastLevel.values[newContrastLevel.toInt()];
+            },
+          ),
+        ],
+      ),
+    );
+  }
+}
+
 
 /// ListTile for changing interpolation settings
 class InterpolationSetting extends StatelessWidget {
@@ -820,6 +865,7 @@ class _Settings extends State<Settings> {
             ),
           ),
           const LooseWeightListTile(),
+          const ContrastLevelSetting(),
           SizedBox(height: TraleTheme.of(context)!.padding),
           Divider(
             height: 2 * TraleTheme.of(context)!.padding,

--- a/app/lib/widget/iconHero.dart
+++ b/app/lib/widget/iconHero.dart
@@ -90,7 +90,7 @@ class _IconHeroStatScreenState extends State<IconHeroStatScreen> {
         SvgAssetLoader(
           assetName,
           colorMapper: TraleIconColorMapper(
-            bgColor: ctheme.onSecondaryContainer,
+            bgColor: ctheme.onSurface,
             wolfColor: ctheme.primary,
             titleColor: ctheme.onSurface,
             sloganColor: ctheme.primary,

--- a/app/lib/widget/linechart.dart
+++ b/app/lib/widget/linechart.dart
@@ -273,7 +273,8 @@ class _CustomLineChartState extends State<CustomLineChart> {
               dotData: const FlDotData(show: false),
               belowBarData: BarAreaData(
                 show: true,
-                color: Theme.of(context).colorScheme.primaryContainer.withAlpha(155),
+                color: Theme.of(context).colorScheme.primaryContainer
+                  .withAlpha(155),
                 // cutOffY: targetWeight ?? 0,
                 // applyCutOffY: targetWeight != null,
               ),

--- a/app/lib/widget/linechart.dart
+++ b/app/lib/widget/linechart.dart
@@ -273,7 +273,7 @@ class _CustomLineChartState extends State<CustomLineChart> {
               dotData: const FlDotData(show: false),
               belowBarData: BarAreaData(
                 show: true,
-                color: Theme.of(context).colorScheme.primaryContainer,
+                color: Theme.of(context).colorScheme.primaryContainer.withAlpha(155),
                 // cutOffY: targetWeight ?? 0,
                 // applyCutOffY: targetWeight != null,
               ),

--- a/app/lib/widget/statsWidgets.dart
+++ b/app/lib/widget/statsWidgets.dart
@@ -53,17 +53,15 @@ class _StatsWidgetsState extends State<StatsWidgets> {
           children: <Widget>[
             AutoSizeText(
               '${notifier.unit.weightToString(utw)} in',
-              style: Theme.of(context).textTheme.bodySmall!.copyWith(
-                color: Theme.of(context).colorScheme.onSecondaryContainer,
-              ),
+              style: Theme.of(context).textTheme.bodySmall!
+                .onSecondaryContainer(context),
             ),
             AutoSizeText(
               timeOfTargetWeight == null
                 ? '--'
                 : timeOfTargetWeight.durationToString(context),
-              style: Theme.of(context).textTheme.bodyLarge!.copyWith(
-                color: Theme.of(context).colorScheme.onSecondaryContainer,
-              ),
+              style: Theme.of(context).textTheme.bodyLarge!
+                .onSecondaryContainer(context),
             ),
           ],
         ),
@@ -88,31 +86,32 @@ class _StatsWidgetsState extends State<StatsWidgets> {
             children: <Widget>[
               AutoSizeText(
                 '${AppLocalizations.of(context)!.change} / $label',
-                style: Theme.of(context).textTheme.bodySmall,
+                style: Theme.of(context).textTheme.bodySmall!
+                  .onSecondaryContainer(context),
               ),
               Row(
                 mainAxisAlignment: MainAxisAlignment.center,
                 children: <Widget>[
                   AutoSizeText(
                     notifier.unit.weightToString(deltaWeight),
-                    style: Theme.of(context).textTheme.bodyLarge!.copyWith(
-                      color: Theme.of(context).colorScheme.onSecondaryContainer,
-                    ),
+                    style: Theme.of(context).textTheme.bodyLarge!
+                      .onSecondaryContainer(context),
                   ),
                   const SizedBox(width: 5),
                   SizedBox(
                     height: sizeOfText(
                       text: '0',
                       context: context,
-                      style: Theme.of(context).textTheme.bodyLarge!.copyWith(
-                        color: Theme.of(context).
-                          colorScheme.onSecondaryContainer,
-                      ),
+                      style: Theme.of(context).textTheme.bodyLarge!
+                        .onSecondaryContainer(context),
                     ).height,
                     child: Transform.rotate(
                       // a change of 1kg / 30d corresponds to 45°
                       angle: -1 * atan(deltaWeight),
-                      child: const Icon( PhosphorIconsRegular.arrowRight),
+                      child: Icon(
+                          PhosphorIconsRegular.arrowRight,
+                        color: Theme.of(context).colorScheme.onSecondaryContainer,
+                      ),
                     ),
                   ),
                 ],
@@ -301,7 +300,7 @@ StatCard getTotalChangeWidget({required BuildContext context,
               child: AutoSizeText(
                 doubleToString(context, stats.deltaWeight),
                 style: Theme.of(context).textTheme.displayLarge!.copyWith(
-                  color: Theme.of(context).colorScheme.onSecondaryContainer,
+                  color: Theme.of(context).colorScheme.onTertiaryContainer,
                   fontWeight: FontWeight.w900,
                   fontSize: 200,
                 ),
@@ -316,7 +315,7 @@ StatCard getTotalChangeWidget({required BuildContext context,
               child: AutoSizeText(
                 '${AppLocalizations.of(context)!.totalChange}\n($unit)',
                 style: Theme.of(context).textTheme.bodyLarge!.copyWith(
-                  color: Theme.of(context).colorScheme.onSecondaryContainer,
+                  color: Theme.of(context).colorScheme.onTertiaryContainer,
                   height: 1.0,
                 ),
                 maxLines: 2,
@@ -398,10 +397,8 @@ StatCard getChangeRatesWidget({required BuildContext context,
             alignment: Alignment.center,
             child: AutoSizeText(
               '${AppLocalizations.of(context)!.change} ($unit)',
-              style: Theme.of(context).textTheme.bodyLarge!.copyWith(
-                color: Theme.of(context).colorScheme.onSecondaryContainer,
-                fontWeight: FontWeight.w900,
-              ),
+              style: Theme.of(context).textTheme.bodyLarge!.onSurface(context)
+                .copyWith(fontWeight: FontWeight.w900),
               maxLines: 2,
               textAlign: TextAlign.center,
             ),
@@ -414,10 +411,8 @@ StatCard getChangeRatesWidget({required BuildContext context,
             child: AutoSizeText(
               '/ ${AppLocalizations.of(context)!.week}\n'
                 '${doubleToString(context, stats.deltaWeightLastWeek)}',
-              style: Theme.of(context).textTheme.bodyMedium!.copyWith(
-                color: Theme.of(context).colorScheme.onSecondaryContainer,
-                height: 1.0,
-              ),
+              style: Theme.of(context).textTheme.bodyMedium!.onSurface(context)
+                .copyWith(height: 1.0),
               maxLines: 2,
               textAlign: TextAlign.center,
             ),
@@ -430,10 +425,8 @@ StatCard getChangeRatesWidget({required BuildContext context,
             child: AutoSizeText(
               '/ ${AppLocalizations.of(context)!.month}\n'
                 '${doubleToString(context, stats.deltaWeightLastMonth)}',
-              style: Theme.of(context).textTheme.bodyMedium!.copyWith(
-                color: Theme.of(context).colorScheme.onSecondaryContainer,
-                height: 1.0,
-              ),
+              style: Theme.of(context).textTheme.bodyMedium!.onSurface(context)
+                .copyWith(height: 1.0),
               maxLines: 2,
               textAlign: TextAlign.center,
             ),
@@ -446,10 +439,8 @@ StatCard getChangeRatesWidget({required BuildContext context,
             child: AutoSizeText(
               '/ ${AppLocalizations.of(context)!.year}\n'
                 '${doubleToString(context, stats.deltaWeightLastYear)}',
-              style: Theme.of(context).textTheme.bodyMedium!.copyWith(
-                color: Theme.of(context).colorScheme.onSecondaryContainer,
-                height: 1.0,
-              ),
+              style: Theme.of(context).textTheme.bodyMedium!.onSurface(context)
+                .copyWith(height: 1.0),
               maxLines: 2,
               textAlign: TextAlign.center,
             ),
@@ -480,9 +471,8 @@ Widget getMinWidget({required BuildContext context,
               alignment: Alignment.center,
               child: AutoSizeText(
                 '${AppLocalizations.of(context)!.min} ($unit)',
-                 style: Theme.of(context).textTheme.bodyLarge!.copyWith(
-                   color: Theme.of(context).colorScheme.onSecondaryContainer,
-                 ),
+                 style: Theme.of(context).textTheme.bodyLarge!
+                   .onSurface(context),
                  maxLines: 1,
               ),
             ),
@@ -493,11 +483,11 @@ Widget getMinWidget({required BuildContext context,
               alignment: Alignment.center,
               child: AutoSizeText(
                 doubleToString(context, stats.minWeight),
-                style: Theme.of(context).textTheme.bodyMedium!.copyWith(
-                  color: Theme.of(context).colorScheme.onSecondaryContainer,
-                  fontWeight: FontWeight.w700,
-                  fontSize: 200,
-                  height: 0.70,
+                style: Theme.of(context).textTheme.bodyMedium!
+                  .onSurface(context).copyWith(
+                    fontWeight: FontWeight.w700,
+                    fontSize: 200,
+                    height: 0.70,
                 ),
                 maxLines: 1,
               ),
@@ -528,8 +518,8 @@ Widget getMaxWidget({required BuildContext context,
               alignment: Alignment.center,
               child: AutoSizeText(
                 doubleToString(context, stats.maxWeight),
-                style: Theme.of(context).textTheme.bodyMedium!.copyWith(
-                  color: Theme.of(context).colorScheme.onSecondaryContainer,
+                style: Theme.of(context).textTheme.bodyMedium!
+                  .onSurface(context).copyWith(
                   fontWeight: FontWeight.w700,
                   fontSize: 200,
                   height: 0.70,
@@ -544,9 +534,8 @@ Widget getMaxWidget({required BuildContext context,
               alignment: Alignment.center,
               child: AutoSizeText(
                 '${AppLocalizations.of(context)!.max} ($unit)',
-                style: Theme.of(context).textTheme.bodyLarge!.copyWith(
-                  color: Theme.of(context).colorScheme.onSecondaryContainer,
-                ),
+                style: Theme.of(context).textTheme.bodyLarge!
+                  .onSurface(context),
                 maxLines: 1,
               ),
             ),


### PR DESCRIPTION
This PR improves to use the correct font colors for the stats widgets, and increases the contrast between the scatter plot and the line plot, #218. Further, it implements an accessibility high contrast mode.

@gwosd What do you think for the new default color of the filled line plot? This should ensure a higher contrast to both, the scatter plot and the tertiaryContainer color.

| new | old |
| ---- | ---- |
| ![new](https://github.com/user-attachments/assets/c425f89c-23db-4f7b-9999-6d7ab84c78e5) | ![old](https://github.com/user-attachments/assets/ae850fe2-bae2-44d3-95b0-1f14e0f4e532) |
| ![new](https://github.com/user-attachments/assets/118a0b4a-ecc5-4150-87a2-107847c34256) | ![old](https://github.com/user-attachments/assets/647d56b4-621e-4537-96ba-f71c69a64430) |
