### PR TITLE
Fix another "loose" / "lose" typo

### DIFF
--- a/app/lib/l10n/app_en.arb
+++ b/app/lib/l10n/app_en.arb
@@ -16,9 +16,9 @@
   "@gainWeight": {
     "description": "Gain weight switch label."
   },
-  "looseWeightSubtitle": "Switching between loosing or gaining weight.",
+  "looseWeightSubtitle": "Switching between losing or gaining weight.",
   "@looseWeightSubtitle": {
-    "description": "Switching between loosing or gaining weight."
+    "description": "Switching between losing or gaining weight."
   },
   "days": "days",
   "@days": {},


### PR DESCRIPTION
This is similar to #270.