### PR TITLE
Add custom color scheme variants

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 [//]: # (### Other changes:)
 
 ## [Unreleased]
+### Added Features and Improvements 🙌:
+- 3 brand new color themes
+- Trale offers now 7 color scheme variants. Check out the settings page 🎉
+
 ### Other changes:
 - Upgrade deps
 - Upgrade building devs (Kotlin, Gradle, Android Application, and NDK)

--- a/app/lib/core/preferences.dart
+++ b/app/lib/core/preferences.dart
@@ -63,6 +63,9 @@ class Preferences {
   /// default for theme
   final String defaultTheme = TraleCustomTheme.water.name;
 
+  /// default scheme variant
+  final String defaultSchemeVariant = TraleSchemeVariant.material.name;
+
   /// default for contrast level
   final ContrastLevel defaultContrastLevel = ContrastLevel.normal;
 
@@ -157,6 +160,13 @@ class Preferences {
 
   /// set theme mode
   set theme(String theme) => prefs.setString('theme', theme);
+
+  /// get scheme variant
+  String get schemeVariant => prefs.getString('schemeVariant')!;
+
+  /// set scheme variant
+  set schemeVariant(String variant) =>
+      prefs.setString('schemeVariant', variant);
 
   /// get contrast level
   ContrastLevel get contrastLevel => prefs.getString('contrastLevel')!
@@ -272,6 +282,9 @@ class Preferences {
     }
     if (override || !prefs.containsKey('theme')) {
       theme = defaultTheme;
+    }
+    if (override || !prefs.containsKey('schemeVariant')) {
+      schemeVariant = defaultSchemeVariant;
     }
     if (override || !prefs.containsKey('contrastLevel')) {
       contrastLevel = defaultContrastLevel;

--- a/app/lib/core/theme.dart
+++ b/app/lib/core/theme.dart
@@ -62,6 +62,7 @@ class TraleTheme {
   TraleTheme({
     required this.seedColor,
     required this.brightness,
+    required this.schemeVariant,
     this.isAmoled=false,
     this.contrast=0.0,
   });
@@ -72,12 +73,14 @@ class TraleTheme {
     Color? seedColor,
     bool? isAmoled,
     double? contrast,
+    DynamicSchemeVariant? schemeVariant,
   }) {
     return TraleTheme(
       brightness: brightness ?? this.brightness,
       seedColor: seedColor ?? this.seedColor,
       isAmoled: isAmoled ?? this.isAmoled,
       contrast: contrast ?? this.contrast,
+      schemeVariant: schemeVariant ?? this.schemeVariant,
     );
   }
 
@@ -96,6 +99,8 @@ class TraleTheme {
   late Color seedColor;
   /// if dark mode on
   late Brightness brightness;
+  /// scheme variant
+  late DynamicSchemeVariant schemeVariant;
   /// Border shape
   final RoundedRectangleBorder borderShape = RoundedRectangleBorder(
     borderRadius: BorderRadius.circular(16),
@@ -177,8 +182,8 @@ class TraleTheme {
       brightness: brightness,
       contrastLevel: contrast,
       dynamicSchemeVariant: isGrey
-        ? DynamicSchemeVariant.fidelity
-        : DynamicSchemeVariant.tonalSpot,
+        ? DynamicSchemeVariant.monochrome
+        : schemeVariant,
     ).harmonized();
     if (isAmoled) {
       colorScheme = colorScheme.copyWith(surface: Colors.black).harmonized();
@@ -285,10 +290,17 @@ extension TraleCustomThemeExtension on TraleCustomTheme {
   double contrast(BuildContext context) =>
     Provider.of<TraleNotifier>(context, listen: false).contrastLevel.contrast;
 
+  DynamicSchemeVariant schemeVariant(BuildContext context) =>
+      Provider
+          .of<TraleNotifier>(context, listen: false)
+          .schemeVariant
+          .schemeVariant;
+
   /// get corresponding light theme
   TraleTheme light(BuildContext context) => TraleTheme(
     seedColor: seedColor(context),
     brightness: Brightness.light,
+    schemeVariant: schemeVariant(context),
     contrast: contrast(context),
   );
 
@@ -296,6 +308,7 @@ extension TraleCustomThemeExtension on TraleCustomTheme {
   TraleTheme dark(BuildContext context) => TraleTheme(
     seedColor: seedColor(context),
     brightness: Brightness.dark,
+    schemeVariant: schemeVariant(context),
     contrast: contrast(context),
   );
 
@@ -415,4 +428,53 @@ extension ColorTextThemeExtension on TextStyle {
   TextStyle onSurfaceVariant(BuildContext context) => copyWith(
     color: Theme.of(context).colorScheme.onSurfaceVariant,
   );
+}
+
+/// enum of all DynamicSchemeVariants
+enum TraleSchemeVariant {
+  /// material
+  material,
+  /// material2 colors
+  material2,
+  /// neutral colors
+  neutral,
+  /// vibrant colors
+  vibrant,
+  /// expressive colors
+  expressive,
+  /// monochrome
+  monochrome,
+  /// content similar to fidelity but matches seed color
+  seed,
+}
+
+/// extend adonisThemes with adding AdonisTheme attributes
+extension TraleSchemeVariantExtension on TraleSchemeVariant {
+  /// get seed color of theme
+  DynamicSchemeVariant get schemeVariant =>
+    <TraleSchemeVariant, DynamicSchemeVariant>{
+    TraleSchemeVariant.material: DynamicSchemeVariant.tonalSpot,
+    TraleSchemeVariant.material2: DynamicSchemeVariant.fidelity,
+    TraleSchemeVariant.neutral: DynamicSchemeVariant.neutral,
+    TraleSchemeVariant.vibrant: DynamicSchemeVariant.vibrant,
+    TraleSchemeVariant.expressive: DynamicSchemeVariant.expressive,
+    TraleSchemeVariant.monochrome: DynamicSchemeVariant.monochrome,
+    TraleSchemeVariant.seed: DynamicSchemeVariant.content,
+  }[this]!;
+
+  /// get string expression
+  String get name => toString().split('.').last;
+}
+
+/// convert string to type
+extension TraleSchemeVariantParsing on String {
+  /// convert string to trale scheme variant
+  TraleSchemeVariant? toTraleSchemeVariant() {
+    for (final TraleSchemeVariant variant in TraleSchemeVariant.values) {
+      if (this == variant.name) {
+        return variant;
+      }
+    }
+    return null;
+  }
 }

--- a/app/lib/core/theme.dart
+++ b/app/lib/core/theme.dart
@@ -162,11 +162,12 @@ class TraleTheme {
     : bgShade3;
 
   /// color threshold for grey
-  final double colorThreshold = 15 / 255;
+  final double colorThreshold = 25 / 255;
 
   /// get if seed color is shade of grey
   bool get isGrey => (seedColor.r - seedColor.g).abs() < colorThreshold
-      && (seedColor.g - seedColor.b).abs() < colorThreshold;
+      && (seedColor.g - seedColor.b).abs() < colorThreshold
+      && (seedColor.r - seedColor.b).abs() < colorThreshold;
 
   /// get corresponding ThemeData
   ThemeData get themeData {
@@ -234,7 +235,7 @@ class TraleTheme {
 }
 
 
-/// defining all workout difficulties
+/// defining all themes
 enum TraleCustomTheme {
   /// system theme A12+
   system,

--- a/app/lib/core/theme.dart
+++ b/app/lib/core/theme.dart
@@ -253,6 +253,12 @@ enum TraleCustomTheme {
   forest,
   /// plum theme
   plum,
+  /// teal theme
+  teal,
+  /// coffee theme
+  coffee,
+  /// amber theme
+  amber,
 }
 
 /// extend adonisThemes with adding AdonisTheme attributes
@@ -270,6 +276,9 @@ extension TraleCustomThemeExtension on TraleCustomTheme {
     TraleCustomTheme.forest: const Color(0xFF006e11),
     TraleCustomTheme.berry: const Color(0xff8b4463),
     TraleCustomTheme.plum: const Color(0xff8e4585),
+    TraleCustomTheme.teal: const Color(0xff008080),
+    TraleCustomTheme.coffee: const Color(0xff6F4E37),
+    TraleCustomTheme.amber: const Color(0xffFFBF00),
   }[this]!;
 
   /// get contrast level

--- a/app/lib/core/traleNotifier.dart
+++ b/app/lib/core/traleNotifier.dart
@@ -70,6 +70,19 @@ class TraleNotifier with ChangeNotifier {
     }
   }
 
+  /// getter
+  TraleSchemeVariant get schemeVariant =>
+      prefs.schemeVariant.toTraleSchemeVariant() ??
+          prefs.defaultSchemeVariant.toTraleSchemeVariant()!;
+
+  /// setter
+  set schemeVariant(TraleSchemeVariant newVariant) {
+    if (newVariant != schemeVariant) {
+      prefs.schemeVariant = newVariant.name;
+      notifyListeners();
+    }
+  }
+
   /// get zoom level
   ZoomLevel get zoomLevel => prefs.zoomLevel;
 

--- a/app/lib/l10n/app_en.arb
+++ b/app/lib/l10n/app_en.arb
@@ -450,6 +450,10 @@
   "@totalChange": {
     "description": "The quantity describing the overall change of body weight"
   },
+  "schemeVariant": "scheme variant",
+  "@schemeVariant": {
+    "description": "(Color) scheme variant label."
+  },
   "mean": "mean",
   "@mean": {
     "description": "The mathematical quantity (arithmetic mean)"

--- a/app/lib/pages/settings.dart
+++ b/app/lib/pages/settings.dart
@@ -186,6 +186,48 @@ class AmoledListTile extends StatelessWidget {
   }
 }
 
+class SchemeVariantListTile extends StatelessWidget {
+  /// constructor
+  const SchemeVariantListTile({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return ListTile(
+      contentPadding: EdgeInsets.symmetric(
+        horizontal: 2 * TraleTheme.of(context)!.padding,
+        vertical: 0.5 * TraleTheme.of(context)!.padding,
+      ),
+      title: AutoSizeText(
+        AppLocalizations.of(context)!.schemeVariant,
+        style: Theme.of(context).textTheme.bodyLarge,
+        maxLines: 1,
+      ),
+      trailing: DropdownMenu<TraleSchemeVariant>(
+        initialSelection: Provider.of<TraleNotifier>(context).schemeVariant,
+        label: AutoSizeText(
+          AppLocalizations.of(context)!.schemeVariant,
+          style: Theme.of(context).textTheme.bodyLarge,
+          maxLines: 1,
+        ),
+        dropdownMenuEntries: <DropdownMenuEntry<TraleSchemeVariant>>[
+          for (final TraleSchemeVariant variant in TraleSchemeVariant.values)
+            DropdownMenuEntry<TraleSchemeVariant>(
+              value: variant,
+              label: variant.name,
+            )
+        ],
+        onSelected: (TraleSchemeVariant? newVariant) async {
+          if (newVariant != null) {
+            Provider
+              .of<TraleNotifier>(context, listen: false)
+              .schemeVariant = newVariant;
+          }
+        },
+      ),
+    );
+  }
+}
+
 /// ListTile for changing Language settings
 class LanguageListTile extends StatelessWidget {
   /// constructor
@@ -829,6 +871,7 @@ class _Settings extends State<Settings> {
             child: const ThemeSelection(),
           ),
           const DarkModeListTile(),
+          const SchemeVariantListTile(),
           const AmoledListTile(),
           Divider(
             height: 2 * TraleTheme.of(context)!.padding,


### PR DESCRIPTION
Nobody asked for it, but here it is:

- 3 more color schemes
- 7 color scheme variants for each (!) color scheme. So the same app, but now more colorful :partying_face: 