### PR TITLE
Add stats custom range settings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ## [Unreleased]
 
 ### Added Features and Improvements 🙌:
+- Rewrite of stats, and stas page
 - Allow to set a target date
 - Allows selecting 0.05kg/st/lb steps for more precision
 - Major performance improvements by making app async

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - Add reminder notifications to prompt daily weight logging
 - Add option to preview interpolation on own data
 - Add changelog to app
+- Add tooltip when scrolling the linechart
 
 ### Other changes:
 - Using the latest flutter 3.41

--- a/app/android/app/proguard-rules.pro
+++ b/app/android/app/proguard-rules.pro
@@ -1,0 +1,2 @@
+# Keep Flutter engine classes accessed via JNI by path_provider_android
+-keep class io.flutter.util.PathUtils { *; }

--- a/app/lib/core/changelog.g.dart
+++ b/app/lib/core/changelog.g.dart
@@ -18,6 +18,7 @@ const Changelog changelog = Changelog(<ChangelogEntry>[
         'Add reminder notifications to prompt daily weight logging',
         'Add option to preview interpolation on own data',
         'Add changelog to app',
+        'Add tooltip when scrolling the linechart',
       ],
       ChangelogSection.otherChanges: <String>[
         'Using the latest flutter 3.41',

--- a/app/lib/core/durationExtension.dart
+++ b/app/lib/core/durationExtension.dart
@@ -24,12 +24,14 @@ extension StringExtension on Duration {
     }
   }
 
-  String durationToStringDays(BuildContext context) {
+  String streakToStringDays(BuildContext context, {bool addLabel = true}) {
     final int days = inDays;
-    if (days == -1) {
-      return '🥳';
-    } else {
-      return '$days ${AppLocalizations.of(context)!.days}';
+    if (!addLabel) {
+      if (days == 0) {
+        return '-';
+      }
+      return '$days';
     }
+    return '$days ${AppLocalizations.of(context)!.days}';
   }
 }

--- a/app/lib/core/measurementDatabase.dart
+++ b/app/lib/core/measurementDatabase.dart
@@ -76,6 +76,14 @@ class MeasurementDatabaseBaseclass {
   /// date of first measurement
   DateTime get firstDate => measurements.last.date;
 
+  /// time span between first and last measurement in days
+  int get measuredTimeSpan =>
+      isEmpty ? 0 : lastDate.difference(firstDate).inDays;
+
+  /// duration between first and last measurement
+  Duration get measurementDuration =>
+      isEmpty ? Duration.zero : lastDate.difference(firstDate);
+
   /// get largest measurement
   Measurement? get max {
     if (measurements.isEmpty) {

--- a/app/lib/core/measurementInterpolation.dart
+++ b/app/lib/core/measurementInterpolation.dart
@@ -552,6 +552,9 @@ class MeasurementInterpolationBaseclass {
   /// Interpolated weights to display (smoothed + extrapolated, display length).
   Vector get weights => _weightsDisplay ??= _createWeightsDisplay();
 
+  /// Content-based hash of the interpolated weights vector.
+  int get hashCode => Object.hashAll(weights);
+
   Vector _createWeightsDisplay() {
     if (_n == 0) {
       return _weights;

--- a/app/lib/core/measurementInterpolation.dart
+++ b/app/lib/core/measurementInterpolation.dart
@@ -632,8 +632,8 @@ class MeasurementInterpolationBaseclass {
             ) +
             _dailyOffsetInHours / 24 * _dayInMs;
 
-  /// Index of the last actual measurement day in display vectors.
-  int get idxLast => times.length - 1 - _offsetInDaysShown;
+  /// Number of days between first and last measurement (inclusive).
+  int get nDays => times.length - 2 * _offsetInDaysShown;
 
   // ---------------------------------------------------------------------------
   // Public API — date-range filtered accessors
@@ -683,21 +683,11 @@ class MeasurementInterpolationBaseclass {
     final Vector m = measurementsInRange(from: from, to: to);
     final Vector mask = isMeasurementInRange(from: from, to: to);
 
-    final List<double> filteredTimes = <double>[];
-    final List<double> filteredMeasurements = <double>[];
-    for (int i = 0; i < mask.length; i++) {
-      if (mask[i] == 1) {
-        filteredTimes.add(t[i]);
-        filteredMeasurements.add(m[i]);
-      }
-    }
+    bool isMeasured(double _, int i) => mask[i] == 1;
+
     return (
-      times: filteredTimes.isEmpty
-          ? Vector.empty()
-          : Vector.fromList(filteredTimes, dtype: dtype),
-      measurements: filteredMeasurements.isEmpty
-          ? Vector.empty()
-          : Vector.fromList(filteredMeasurements, dtype: dtype),
+      times: t.filterElements(isMeasured),
+      measurements: m.filterElements(isMeasured),
     );
   }
 

--- a/app/lib/core/measurementInterpolation.dart
+++ b/app/lib/core/measurementInterpolation.dart
@@ -277,22 +277,21 @@ class MeasurementInterpolationBaseclass {
 
   /// re initialize database
   void reinit() {
-    _dateTimes = null;
-    _times = null;
-    _timesIdx = null;
-    _timesMeasured = null;
+    __dateTimes = null;
+    __times = null;
+    __timesIdx = null;
+    __timesMeasured = null;
     _timesDisplay = null;
-    _weightsMeasured = null;
-    _weights = null;
+    __weightsMeasured = null;
+    __weights = null;
     _weightsDisplay = null;
     _measurementsDisplay = null;
     _isMeasurementDisplay = null;
-    _isNoMeasurement = null;
-    _isNotExtrapolated = null;
-    _sigma = null;
-    _weightsLinExtrapol = null;
-    _weightsSmoothed = null;
-    _weightsGaussianExtrapol = null;
+    __isNoMeasurement = null;
+    __sigma = null;
+    __weightsLinExtrapol = null;
+    __weightsSmoothed = null;
+    __weightsGaussianExtrapol = null;
 
     // recalculate all vectors
     init();
@@ -302,29 +301,28 @@ class MeasurementInterpolationBaseclass {
   /// pipeline — linear interpolation, Gaussian regression, Gaussian smoothing,
   /// and weightsDisplay — to a background isolate via [compute]).
   Future<void> reinitAsync() async {
-    _dateTimes = null;
-    _times = null;
-    _timesIdx = null;
-    _timesMeasured = null;
+    __dateTimes = null;
+    __times = null;
+    __timesIdx = null;
+    __timesMeasured = null;
     _timesDisplay = null;
-    _weightsMeasured = null;
-    _weights = null;
+    __weightsMeasured = null;
+    __weights = null;
     _weightsDisplay = null;
     _measurementsDisplay = null;
     _isMeasurementDisplay = null;
-    _isNoMeasurement = null;
-    _isNotExtrapolated = null;
-    _sigma = null;
-    _weightsLinExtrapol = null;
-    _weightsSmoothed = null;
-    _weightsGaussianExtrapol = null;
+    __isNoMeasurement = null;
+    __sigma = null;
+    __weightsLinExtrapol = null;
+    __weightsSmoothed = null;
+    __weightsGaussianExtrapol = null;
 
     // Compute the lightweight synchronous vectors first (times, weights,
     // isMeasurement, idxsMeasurements).  These are O(N) and fast.
-    times;
-    weights;
+    _times;
+    _weights;
 
-    if (N == 0) {
+    if (_n == 0) {
       return;
     }
 
@@ -332,12 +330,12 @@ class MeasurementInterpolationBaseclass {
     final _InterpolationResult result = await compute(
       _computeFullInterpolation,
       _InterpolationPayload(
-        timesData: times.toList(),
-        weightsData: weights.toList(),
-        isMeasurementData: isMeasurement.toList(),
-        isNoMeasurementData: isNoMeasurement.toList(),
-        idxsMeasurements: idxsMeasurements,
-        n: N,
+        timesData: _times.toList(),
+        weightsData: _weights.toList(),
+        isMeasurementData: _isMeasurement.toList(),
+        isNoMeasurementData: _isNoMeasurement.toList(),
+        idxsMeasurements: _idxsMeasurements,
+        n: _n,
         offsetInDays: _offsetInDays,
         offsetInDaysShown: _offsetInDaysShown,
         strengthMeasurement: interpolStrength.strengthMeasurement,
@@ -348,48 +346,45 @@ class MeasurementInterpolationBaseclass {
     );
 
     // Store the results.
-    _weightsSmoothed = Vector.fromList(result.weightsSmoothed, dtype: dtype);
-    _weightsLinExtrapol = Vector.fromList(
+    __weightsSmoothed = Vector.fromList(result.weightsSmoothed, dtype: dtype);
+    __weightsLinExtrapol = Vector.fromList(
       result.weightsLinExtrapol,
       dtype: dtype,
     );
-    _weightsGaussianExtrapol = Vector.fromList(
+    __weightsGaussianExtrapol = Vector.fromList(
       result.weightsGaussianExtrapol,
       dtype: dtype,
     );
     _weightsDisplay = Vector.fromList(result.weightsDisplay, dtype: dtype);
 
     // Derive remaining display vectors (cheap subvector / offset ops).
-    timesDisplay;
-    measurementsDisplay;
-    isMeasurementDisplay;
+    times;
+    measurements;
+    isMeasurement;
   }
 
   /// initialize database
   void init() {
-    times;
-    weights;
+    _times;
+    _weights;
 
-    weightsGaussianExtrapol;
-    weightsDisplay;
+    _weightsGaussianExtrapol;
+    weights;
   }
 
   /// data type of vectors
   static const DType dtype = DType.float64;
 
-  /// length of vectors
-  // ignore: non_constant_identifier_names
-  int get N => times.length;
+  // ---------------------------------------------------------------------------
+  // Internal (length-N) vectors — all private
+  // ---------------------------------------------------------------------------
 
-  /// length of displayed vectors
-  int get nDisplay => timesDisplay.length;
+  /// internal length of full vectors (including extrapolation padding)
+  int get _n => _times.length;
 
-  List<DateTime>? _dateTimes;
+  List<DateTime>? __dateTimes;
+  List<DateTime> get _dateTimes => __dateTimes ??= _createDateTimes();
 
-  /// get vector containing the times given in [ms since epoch]
-  List<DateTime> get dateTimes => _dateTimes ??= _createDateTimes();
-
-  /// get DateTime List corresponding to times and weights
   List<DateTime> _createDateTimes() {
     if (db.nMeasurements == 0) {
       return <DateTime>[];
@@ -408,32 +403,19 @@ class MeasurementInterpolationBaseclass {
     );
   }
 
-  /// number of measurements
-  int get nMeasurements => timesMeasured.length;
+  /// idx of last measurement in internal vectors
+  int get _idxLast => _n - 1 - _offsetInDays;
 
-  /// time span of measurements
-  int get measuredTimeSpan => N == 0 ? 0 : N - 2 * _offsetInDays;
+  Vector? __times;
+  Vector get _times => __times ??= _createTimes();
 
-  /// idx of last measurement
-  int get idxLast => N - 1 - _offsetInDays;
-
-  /// idx of last displayed measurement
-  int get idxLastDisplay => nDisplay - 1 - _offsetInDaysShown;
-
-  Vector? _times;
-
-  /// get vector containing the times given in [ms since epoch]
-  Vector get times => _times ??= _createTimes();
-
-  /// get linearly interpolated and sorted list of daily-averaged measurements
   Vector _createTimes() {
-    final List<DateTime> dts = dateTimes;
+    final List<DateTime> dts = _dateTimes;
     if (dts.isEmpty) {
-      _isExtrapolated = Vector.empty();
+      __isExtrapolated = Vector.empty();
       return Vector.empty();
     }
-    // set isExtrapolated
-    _isExtrapolated = Vector.fromList(
+    __isExtrapolated = Vector.fromList(
       List<int>.generate(
         dts.length,
         (int idx) =>
@@ -448,55 +430,44 @@ class MeasurementInterpolationBaseclass {
     );
   }
 
-  List<int>? _timesIdx;
+  List<int>? __timesIdx;
+  List<int> get _timesIdx =>
+      __timesIdx ??= List<int>.generate(_n, (int idx) => idx);
 
-  /// get vector containing the times given in [ms since epoch]
-  List<int> get timesIdx =>
-      _timesIdx ??= List<int>.generate(N, (int idx) => idx);
+  Vector? __timesMeasured;
+  Vector get _timesMeasured => __timesMeasured ??= _createTimesMeasured();
 
-  Vector? _timesMeasured;
-
-  /// get vector containing the times of the measurements
-  Vector get timesMeasured => _timesMeasured ??= _createTimesMeasured();
-
-  /// create vector of all measurements time stamps
   Vector _createTimesMeasured() {
     return Vector.fromList(<int>[
       for (final Measurement ms in db.measurements.reversed) ms.dateInMs,
     ], dtype: dtype);
   }
 
-  Vector? _weightsMeasured;
+  Vector? __weightsMeasured;
+  Vector get _weightsMeasured => __weightsMeasured ??= _createWeightsMeasured();
 
-  /// get vector containing the weights of the measurements [kg]
-  Vector get weightsMeasured => _weightsMeasured ??= _createWeightsMeasured();
-
-  /// create vector of all measurements weights
   Vector _createWeightsMeasured() {
     return Vector.fromList(<double>[
       for (final Measurement ms in db.measurements.reversed) ms.weight,
     ], dtype: dtype);
   }
 
-  Vector? _weights;
+  Vector? __weights;
+  Vector get _weights => __weights ??= _createWeights();
 
-  /// get vector containing the measurements corresponding to self.times
-  Vector get weights => _weights ??= _createWeights();
-
-  /// get linearly interpolated and sorted list of daily-averaged measurements
   Vector _createWeights() {
-    if (N == 0) {
-      _isMeasurement = Vector.empty();
-      _idxsMeasurements = <int>[];
+    if (_n == 0) {
+      __isMeasurement = Vector.empty();
+      __idxsMeasurements = <int>[];
       return Vector.empty();
     }
-    final List<double> ms = Vector.zero(N).toList();
-    final List<double> counts = Vector.zero(N).toList();
+    final List<double> ms = Vector.zero(_n).toList();
+    final List<double> counts = Vector.zero(_n).toList();
     final List<int> idxMs = <int>[];
 
     int idx = 0;
     for (final Measurement m in db.measurements.reversed) {
-      while (!m.date.sameDay(dateTimes[idx])) {
+      while (!m.date.sameDay(_dateTimes[idx])) {
         idx += 1;
       }
       ms[idx] += m.weight;
@@ -506,102 +477,81 @@ class MeasurementInterpolationBaseclass {
       }
     }
 
-    // set isMeasurement
-    _isMeasurement =
+    __isMeasurement =
         Vector.fromList(counts, dtype: dtype) /
         Vector.fromList(counts).mapToVector((double val) => val == 0 ? 1 : val);
 
-    _idxsMeasurements = idxMs;
+    __idxsMeasurements = idxMs;
 
     return Vector.fromList(ms, dtype: dtype) /
         Vector.fromList(counts).mapToVector((double val) => val == 0 ? 1 : val);
   }
 
-  late Vector _isMeasurement;
+  late Vector __isMeasurement;
+  Vector get _isMeasurement => __isMeasurement;
 
-  /// get vector containing 1 if measurement else 0
-  Vector get isMeasurement => _isMeasurement;
+  Vector? __isNoMeasurement;
+  Vector get _isNoMeasurement =>
+      __isNoMeasurement ??= (_isMeasurement - 1).abs();
 
-  Vector? _isNoMeasurement;
+  late List<int> __idxsMeasurements;
+  List<int> get _idxsMeasurements => __idxsMeasurements;
 
-  /// get vector containing 0 if measurement else 1
-  Vector get isNoMeasurement => _isNoMeasurement ??= (isMeasurement - 1).abs();
+  late Vector __isExtrapolated;
+  Vector get _isExtrapolated => __isExtrapolated;
 
-  late List<int> _idxsMeasurements;
-
-  /// get List holding indices to all measurements
-  List<int> get idxsMeasurements => _idxsMeasurements;
-
-  late Vector _isExtrapolated;
-
-  /// get vector containing 0 if values are outside of measurement range else 1
-  Vector get isExtrapolated => _isExtrapolated;
-
-  Vector? _isNotExtrapolated;
-
-  /// get vector containing 1 if values withing measurement range else 0
-  Vector get isNotExtrapolated => _isNotExtrapolated ??= isExtrapolated
-      .mapToVector((double val) => val == 0 ? 1 : 0);
-
-  Vector? _sigma;
-
-  /// get vector containing sigma depending if measurement or not [ms]
-  Vector get sigma => _sigma ??=
-      (isMeasurement * interpolStrength.strengthMeasurement +
-          isNoMeasurement * interpolStrength.strengthInterpol) *
+  Vector? __sigma;
+  Vector get _sigma => __sigma ??=
+      (_isMeasurement * interpolStrength.strengthMeasurement +
+          _isNoMeasurement * interpolStrength.strengthInterpol) *
       _dayInMs;
 
-  /// estimate weights of gaussian at time t with std sigma
-  Vector gaussianWeights(double t, Vector ms) {
-    final Vector norm = (sigma * math.sqrt(2 * math.pi)).pow(-1);
-    final Vector gaussianWeights =
-        ((times - t).pow(2) / (sigma.pow(2) * -2)).exp() *
+  Vector _gaussianWeights(double t, Vector ms) {
+    final Vector norm = (_sigma * math.sqrt(2 * math.pi)).pow(-1);
+    final Vector gw =
+        ((_times - t).pow(2) / (_sigma.pow(2) * -2)).exp() *
         norm *
-        (isMeasurement * interpolStrength.weight + isNoMeasurement);
+        (_isMeasurement * interpolStrength.weight + _isNoMeasurement);
     final Vector mask = ms.mapToVector((double val) => val > 0 ? 1 : 0);
 
-    return (gaussianWeights * mask) / (gaussianWeights * mask).sum();
+    return (gw * mask) / (gw * mask).sum();
   }
 
-  /// take mean of Vector ws weighted with Gaussian N(t, sigma)
-  double gaussianMean(double t, Vector ms) => gaussianWeights(t, ms).dot(ms);
+  double _gaussianMean(double t, Vector ms) => _gaussianWeights(t, ms).dot(ms);
 
-  Vector? _weightsSmoothed;
-
-  /// get vector containing the Gaussian smoothed measurements
-  Vector get weightsSmoothed => _weightsSmoothed ??=
+  Vector? __weightsSmoothed;
+  Vector get _weightsSmoothed => __weightsSmoothed ??=
       _gaussianInterpolation(
-        _linearExtrapolation(_linearInterpolation(weights)),
+        _linearExtrapolation(_linearInterpolation(_weights)),
       ) *
-      isMeasurement; // set all non Measurements to zero.
+      _isMeasurement;
 
-  Vector? _weightsLinExtrapol;
+  Vector? __weightsLinExtrapol;
+  Vector get _weightsLinExtrapol => __weightsLinExtrapol ??=
+      _linearExtrapolation(_linearInterpolation(_weightsSmoothed));
 
-  /// get vector containing the weights with linear interpolated missing values
-  Vector get weightsLinExtrapol => _weightsLinExtrapol ??= _linearExtrapolation(
-    _linearInterpolation(weightsSmoothed),
-  );
+  Vector? __weightsGaussianExtrapol;
+  Vector get _weightsGaussianExtrapol =>
+      __weightsGaussianExtrapol ??= _gaussianInterpolation(_weightsLinExtrapol);
 
-  Vector? _weightsGaussianExtrapol;
-
-  /// get vector containing the weights with linear interpolated missing values
-  Vector get weightsGaussianExtrapol =>
-      _weightsGaussianExtrapol ??= _gaussianInterpolation(weightsLinExtrapol);
+  // ---------------------------------------------------------------------------
+  // Public API — display-length vectors
+  // ---------------------------------------------------------------------------
 
   Vector? _weightsDisplay;
 
-  /// get vector containing the weights to display
-  Vector get weightsDisplay => _weightsDisplay ??= _createWeightsDisplay();
+  /// Interpolated weights to display (smoothed + extrapolated, display length).
+  Vector get weights => _weightsDisplay ??= _createWeightsDisplay();
 
   Vector _createWeightsDisplay() {
-    if (N == 0) {
-      return weights;
+    if (_n == 0) {
+      return _weights;
     }
 
     if (interpolStrength == InterpolStrength.none) {
       final Vector weightsLinear = _linearInterpolation(
-        weights,
-      ).subvector(_offsetInDays, N - _offsetInDays);
+        _weights,
+      ).subvector(_offsetInDays, _n - _offsetInDays);
 
       final Vector weightsExtrapol =
           Vector.fromList(<double>[
@@ -612,113 +562,184 @@ class MeasurementInterpolationBaseclass {
 
       return Vector.fromList(weightsLinear.toList()..addAll(weightsExtrapol));
     }
-    return weightsGaussianExtrapol.subvector(
+    return _weightsGaussianExtrapol.subvector(
       _offsetInDays - _offsetInDaysShown,
-      N - _offsetInDays + _offsetInDaysShown,
+      _n - _offsetInDays + _offsetInDaysShown,
     );
   }
 
   Vector? _measurementsDisplay;
 
-  /// get vector containing the raw (daily-averaged) measurements aligned with
-  /// [timesDisplay]. 0 on days without a measurement.
-  Vector get measurementsDisplay =>
+  /// Raw (daily-averaged) measurements aligned with [times].
+  /// 0 on days without a measurement.
+  Vector get measurements =>
       _measurementsDisplay ??= _createMeasurementsDisplay();
 
   Vector _createMeasurementsDisplay() {
-    if (N == 0) {
-      return weights;
+    if (_n == 0) {
+      return _weights;
     }
     if (interpolStrength == InterpolStrength.none) {
-      final Vector slice = weights.subvector(_offsetInDays, N - _offsetInDays);
+      final Vector slice = _weights.subvector(
+        _offsetInDays,
+        _n - _offsetInDays,
+      );
       return Vector.fromList(
         slice.toList()..addAll(List<double>.filled(_offsetInDaysShown, 0)),
       );
     }
-    return weights.subvector(
+    return _weights.subvector(
       _offsetInDays - _offsetInDaysShown,
-      N - _offsetInDays + _offsetInDaysShown,
+      _n - _offsetInDays + _offsetInDaysShown,
     );
   }
 
   Vector? _isMeasurementDisplay;
 
-  /// get vector containing 1 if [timesDisplay] entry has a measurement, 0
-  /// otherwise.
-  Vector get isMeasurementDisplay =>
+  /// 1 if the corresponding [times] entry has a measurement, 0 otherwise.
+  Vector get isMeasurement =>
       _isMeasurementDisplay ??= _createIsMeasurementDisplay();
 
   Vector _createIsMeasurementDisplay() {
-    if (N == 0) {
-      return isMeasurement;
+    if (_n == 0) {
+      return _isMeasurement;
     }
     if (interpolStrength == InterpolStrength.none) {
-      final Vector slice = isMeasurement.subvector(
+      final Vector slice = _isMeasurement.subvector(
         _offsetInDays,
-        N - _offsetInDays,
+        _n - _offsetInDays,
       );
       return Vector.fromList(
         slice.toList()..addAll(List<double>.filled(_offsetInDaysShown, 0)),
       );
     }
-    return isMeasurement.subvector(
+    return _isMeasurement.subvector(
       _offsetInDays - _offsetInDaysShown,
-      N - _offsetInDays + _offsetInDaysShown,
+      _n - _offsetInDays + _offsetInDaysShown,
     );
   }
 
   Vector? _timesDisplay;
 
-  /// get vector containing the weights to display
-  Vector get timesDisplay => _timesDisplay ??= N == 0
-      ? times
-      : times.subvector(
+  /// Times in ms since epoch, display length (one entry per day).
+  Vector get times => _timesDisplay ??= _n == 0
+      ? _times
+      : _times.subvector(
               (interpolStrength == InterpolStrength.none)
                   ? _offsetInDays
                   : _offsetInDays - _offsetInDaysShown,
-              N - _offsetInDays + _offsetInDaysShown,
+              _n - _offsetInDays + _offsetInDaysShown,
             ) +
             _dailyOffsetInHours / 24 * _dayInMs;
 
-  /// add linear interpolation to measurements
-  Vector _linearExtrapolation(Vector weights) {
-    final List<double> weightsList = weights.toList();
+  /// Index of the last actual measurement day in display vectors.
+  int get idxLast => times.length - 1 - _offsetInDaysShown;
+
+  // ---------------------------------------------------------------------------
+  // Public API — date-range filtered accessors
+  // ---------------------------------------------------------------------------
+
+  /// Return the pair of display-vector indices for the optional date range.
+  /// If [from] is null, starts at 0. If [to] is null, ends at the last index.
+  (int start, int end) _displayRange({DateTime? from, DateTime? to}) {
+    final int start = from != null ? (indexForDay(from) ?? 0) : 0;
+    final int end = to != null
+        ? ((indexForDay(to) ?? times.length - 1) + 1)
+        : times.length;
+    return (start, end);
+  }
+
+  /// Subvector of [times] between [from] and [to].
+  Vector timesInRange({DateTime? from, DateTime? to}) {
+    final (int start, int end) = _displayRange(from: from, to: to);
+    return times.subvector(start, end);
+  }
+
+  /// Subvector of [weights] between [from] and [to].
+  Vector weightsInRange({DateTime? from, DateTime? to}) {
+    final (int start, int end) = _displayRange(from: from, to: to);
+    return weights.subvector(start, end);
+  }
+
+  /// Subvector of [measurements] between [from] and [to].
+  Vector measurementsInRange({DateTime? from, DateTime? to}) {
+    final (int start, int end) = _displayRange(from: from, to: to);
+    return measurements.subvector(start, end);
+  }
+
+  /// Subvector of [isMeasurement] between [from] and [to].
+  Vector isMeasurementInRange({DateTime? from, DateTime? to}) {
+    final (int start, int end) = _displayRange(from: from, to: to);
+    return isMeasurement.subvector(start, end);
+  }
+
+  /// Return only the actual measurement data points (filtering out
+  /// interpolated days) within the optional date range.
+  ({Vector times, Vector measurements}) measured({
+    DateTime? from,
+    DateTime? to,
+  }) {
+    final Vector t = timesInRange(from: from, to: to);
+    final Vector m = measurementsInRange(from: from, to: to);
+    final Vector mask = isMeasurementInRange(from: from, to: to);
+
+    final List<double> filteredTimes = <double>[];
+    final List<double> filteredMeasurements = <double>[];
+    for (int i = 0; i < mask.length; i++) {
+      if (mask[i] == 1) {
+        filteredTimes.add(t[i]);
+        filteredMeasurements.add(m[i]);
+      }
+    }
+    return (
+      times: filteredTimes.isEmpty
+          ? Vector.empty()
+          : Vector.fromList(filteredTimes, dtype: dtype),
+      measurements: filteredMeasurements.isEmpty
+          ? Vector.empty()
+          : Vector.fromList(filteredMeasurements, dtype: dtype),
+    );
+  }
+
+  // ---------------------------------------------------------------------------
+  // Internal interpolation helpers
+  // ---------------------------------------------------------------------------
+
+  Vector _linearExtrapolation(Vector w) {
+    final List<double> wList = w.toList();
 
     if (db.nMeasurements == 0) {
       return Vector.empty();
-    } else if (idxsMeasurements.length == 1) {
-      return Vector.filled(N, weights[idxsMeasurements[0]]);
+    } else if (_idxsMeasurements.length == 1) {
+      return Vector.filled(_n, w[_idxsMeasurements[0]]);
     }
 
-    // add extrapolation
     final Vector initialExtrapolation = _linearRegression(
-      weights,
-      times[_offsetInDays],
-      times.subvector(0, _offsetInDays),
+      w,
+      _times[_offsetInDays],
+      _times.subvector(0, _offsetInDays),
     );
     final Vector finalExtrapolation = _linearRegression(
-      weights,
-      times[N - _offsetInDays],
-      times.subvector(N - _offsetInDays, N),
+      w,
+      _times[_n - _offsetInDays],
+      _times.subvector(_n - _offsetInDays, _n),
     );
 
     for (int idx = 0; idx < _offsetInDays; idx++) {
-      weightsList[idx] = initialExtrapolation[idx];
-      weightsList[N - _offsetInDays + idx] = finalExtrapolation[idx];
+      wList[idx] = initialExtrapolation[idx];
+      wList[_n - _offsetInDays + idx] = finalExtrapolation[idx];
     }
 
-    return Vector.fromList(weightsList, dtype: dtype);
+    return Vector.fromList(wList, dtype: dtype);
   }
 
-  /// Estimate linear regression for time ts with Gaussian weights relative to
-  /// tRef
-  Vector _linearRegression(Vector weights, double tRef, Vector ts) {
-    final Vector gsWeights = gaussianWeights(tRef, weights);
-    final double meanWeight = gsWeights.dot(weights);
-    final double meanTime = gsWeights.dot(times);
+  Vector _linearRegression(Vector w, double tRef, Vector ts) {
+    final Vector gsWeights = _gaussianWeights(tRef, w);
+    final double meanWeight = gsWeights.dot(w);
+    final double meanTime = gsWeights.dot(_times);
     final double meanChange =
-        gsWeights.dot((weights - meanWeight) * times) /
-        gsWeights.dot((times - meanTime) * times);
+        gsWeights.dot((w - meanWeight) * _times) /
+        gsWeights.dot((_times - meanTime) * _times);
     final double intercept = meanWeight - meanChange * meanTime;
 
     return Vector.fromList(<double>[
@@ -727,66 +748,52 @@ class MeasurementInterpolationBaseclass {
     ], dtype: dtype);
   }
 
-  /// add linear interpolation to measurements
-  Vector _linearInterpolation(Vector weights) {
-    final List<double> weightsList = weights.toList();
+  Vector _linearInterpolation(Vector w) {
+    final List<double> wList = w.toList();
     int idxFrom, idxTo;
     double changeRate;
 
     if (db.nMeasurements == 0) {
       return Vector.empty();
-    } else if (idxsMeasurements.length == 1) {
-      return Vector.filled(N, weights[idxsMeasurements[0]]);
+    } else if (_idxsMeasurements.length == 1) {
+      return Vector.filled(_n, w[_idxsMeasurements[0]]);
     }
 
-    // loop over all unique measurements
-    for (int idx = 0; idx < idxsMeasurements.length - 1; idx++) {
-      // interpolate between measurements idxs_i and idx_j
-      idxFrom = idxsMeasurements[idx];
-      idxTo = idxsMeasurements[idx + 1];
+    for (int idx = 0; idx < _idxsMeasurements.length - 1; idx++) {
+      idxFrom = _idxsMeasurements[idx];
+      idxTo = _idxsMeasurements[idx + 1];
       if (idxFrom + 1 < idxTo) {
-        // estimate change rate
-        changeRate = _slope(idxFrom, idxTo, weights);
+        changeRate = _slope(idxFrom, idxTo, w);
         for (int idxJ = idxFrom + 1; idxJ < idxTo; idxJ++) {
-          weightsList[idxJ] =
-              weightsList[idxFrom] + changeRate * (idxJ - idxFrom);
+          wList[idxJ] = wList[idxFrom] + changeRate * (idxJ - idxFrom);
         }
       }
     }
-    return Vector.fromList(weightsList, dtype: dtype);
+    return Vector.fromList(wList, dtype: dtype);
   }
 
-  /// estimate slope between two measurements in [kg/steps]
-  double _slope(int idxFrom, int idxTo, Vector weights) => weights.isNotEmpty
-      ? (weights[idxTo] - weights[idxFrom]) / (idxTo - idxFrom)
-      : 0;
+  double _slope(int idxFrom, int idxTo, Vector w) =>
+      w.isNotEmpty ? (w[idxTo] - w[idxFrom]) / (idxTo - idxFrom) : 0;
 
-  /// smooth weights with Gaussian kernel
-  Vector _gaussianInterpolation(Vector weights) => Vector.fromList(<double>[
-    for (final int idx in timesIdx)
-      (weights[idx] != 0) ? gaussianMean(times[idx], weights) : 0,
+  Vector _gaussianInterpolation(Vector w) => Vector.fromList(<double>[
+    for (final int idx in _timesIdx)
+      (w[idx] != 0) ? _gaussianMean(_times[idx], w) : 0,
   ], dtype: dtype);
 
-  /// get time span between first and last measurement
-  Duration get measurementDuration => timesMeasured.isNotEmpty
-      ? Duration(
-          milliseconds: (timesMeasured.last - timesMeasured.first).round(),
-        )
-      : Duration.zero;
+  // ---------------------------------------------------------------------------
+  // Public API — scalar helpers
+  // ---------------------------------------------------------------------------
 
-  /// final slope of extrapolation
+  /// Final slope of extrapolation [kg/day].
   double get finalSlope =>
-      _slope(idxLast, idxLast + _offsetInDaysShown, weightsGaussianExtrapol);
+      _slope(_idxLast, _idxLast + _offsetInDaysShown, _weightsGaussianExtrapol);
 
-  /// Return the index into [weightsDisplay] for a given [day], or null
+  /// Return the index into display vectors for a given [day], or null
   /// if [day] falls outside the display range.
-  int? displayIndexForDay(DateTime day) {
-    if (nDisplay == 0) {
+  int? indexForDay(DateTime day) {
+    if (times.isEmpty) {
       return null;
     }
-    // timesDisplay is uniformly spaced at _dayInMs intervals with a 12 h
-    // offset.  Adding the same offset to the query day makes the difference
-    // an exact multiple of _dayInMs, so the index is a simple division.
     final double dayMs =
         DateTime(
           day.year,
@@ -794,33 +801,33 @@ class MeasurementInterpolationBaseclass {
           day.day,
         ).millisecondsSinceEpoch.toDouble() +
         _dailyOffsetInHours / 24 * _dayInMs;
-    final int displayIdx = ((dayMs - timesDisplay.first) / _dayInMs).round();
-    if (displayIdx < 0 || displayIdx >= nDisplay) {
+    final int idx = ((dayMs - times.first) / _dayInMs).round();
+    if (idx < 0 || idx >= times.length) {
       return null;
     }
-    return displayIdx;
+    return idx;
   }
 
   /// Return the interpolated weight for [day], or null if out of range.
   double? interpolationForDay(DateTime day) {
-    final int? idx = displayIndexForDay(day);
-    return idx != null ? weightsDisplay[idx] : null;
+    final int? idx = indexForDay(day);
+    return idx != null ? weights[idx] : null;
   }
 
   /// Return the raw measurement for [day], or null if out of range or no
   /// measurement on that day.
   double? measurementForDay(DateTime day) {
-    final int? idx = displayIndexForDay(day);
-    if (idx == null || isMeasurementDisplay[idx] == 0) {
+    final int? idx = indexForDay(day);
+    if (idx == null || isMeasurement[idx] == 0) {
       return null;
     }
-    return measurementsDisplay[idx];
+    return measurements[idx];
   }
 
   /// Whether a measurement exists on [day].
   bool hasMeasurementOnDay(DateTime day) {
-    final int? idx = displayIndexForDay(day);
-    return idx != null && isMeasurementDisplay[idx] == 1;
+    final int? idx = indexForDay(day);
+    return idx != null && isMeasurement[idx] == 1;
   }
 
   /// offset of day in interpolation
@@ -919,24 +926,24 @@ class MeasurementInterpolation extends MeasurementInterpolationBaseclass {
       }
 
       // Restore all vectors
-      _dateTimes = (map['dateTimes'] as List<dynamic>)
+      __dateTimes = (map['dateTimes'] as List<dynamic>)
           .map(
             (dynamic ms) =>
                 DateTime.fromMillisecondsSinceEpoch((ms as num).toInt()),
           )
           .toList();
-      _times = _vectorFromJson(map['times']);
-      _isExtrapolated = _vectorFromJson(map['isExtrapolated']);
-      _weights = _vectorFromJson(map['weights']);
-      _isMeasurement = _vectorFromJson(map['isMeasurement']);
-      _idxsMeasurements = (map['idxsMeasurements'] as List<dynamic>)
+      __times = _vectorFromJson(map['times']);
+      __isExtrapolated = _vectorFromJson(map['isExtrapolated']);
+      __weights = _vectorFromJson(map['weights']);
+      __isMeasurement = _vectorFromJson(map['isMeasurement']);
+      __idxsMeasurements = (map['idxsMeasurements'] as List<dynamic>)
           .map((dynamic e) => (e as num).toInt())
           .toList();
-      _timesMeasured = _vectorFromJson(map['timesMeasured']);
-      _weightsMeasured = _vectorFromJson(map['weightsMeasured']);
-      _weightsSmoothed = _vectorFromJson(map['weightsSmoothed']);
-      _weightsLinExtrapol = _vectorFromJson(map['weightsLinExtrapol']);
-      _weightsGaussianExtrapol = _vectorFromJson(
+      __timesMeasured = _vectorFromJson(map['timesMeasured']);
+      __weightsMeasured = _vectorFromJson(map['weightsMeasured']);
+      __weightsSmoothed = _vectorFromJson(map['weightsSmoothed']);
+      __weightsLinExtrapol = _vectorFromJson(map['weightsLinExtrapol']);
+      __weightsGaussianExtrapol = _vectorFromJson(
         map['weightsGaussianExtrapol'],
       );
       _weightsDisplay = _vectorFromJson(map['weightsDisplay']);
@@ -965,23 +972,23 @@ class MeasurementInterpolation extends MeasurementInterpolationBaseclass {
         'interpolStrength': interpolStrength.name,
         'firstDateMs': db.firstDate.millisecondsSinceEpoch,
         'lastDateMs': db.lastDate.millisecondsSinceEpoch,
-        'dateTimes': dateTimes
+        'dateTimes': _dateTimes
             .map((DateTime dt) => dt.millisecondsSinceEpoch)
             .toList(),
-        'times': times.toList(),
-        'isExtrapolated': isExtrapolated.toList(),
-        'weights': weights.toList(),
-        'isMeasurement': isMeasurement.toList(),
-        'idxsMeasurements': idxsMeasurements,
-        'timesMeasured': timesMeasured.toList(),
-        'weightsMeasured': weightsMeasured.toList(),
-        'weightsSmoothed': weightsSmoothed.toList(),
-        'weightsLinExtrapol': weightsLinExtrapol.toList(),
-        'weightsGaussianExtrapol': weightsGaussianExtrapol.toList(),
-        'weightsDisplay': weightsDisplay.toList(),
-        'measurementsDisplay': measurementsDisplay.toList(),
-        'isMeasurementDisplay': isMeasurementDisplay.toList(),
-        'timesDisplay': timesDisplay.toList(),
+        'times': _times.toList(),
+        'isExtrapolated': _isExtrapolated.toList(),
+        'weights': _weights.toList(),
+        'isMeasurement': _isMeasurement.toList(),
+        'idxsMeasurements': _idxsMeasurements,
+        'timesMeasured': _timesMeasured.toList(),
+        'weightsMeasured': _weightsMeasured.toList(),
+        'weightsSmoothed': _weightsSmoothed.toList(),
+        'weightsLinExtrapol': _weightsLinExtrapol.toList(),
+        'weightsGaussianExtrapol': _weightsGaussianExtrapol.toList(),
+        'weightsDisplay': weights.toList(),
+        'measurementsDisplay': measurements.toList(),
+        'isMeasurementDisplay': isMeasurement.toList(),
+        'timesDisplay': times.toList(),
       };
       Preferences().prefs.setString(_cacheKey, jsonEncode(map));
     } catch (e) {

--- a/app/lib/core/measurementInterpolation.dart
+++ b/app/lib/core/measurementInterpolation.dart
@@ -703,6 +703,25 @@ class MeasurementInterpolationBaseclass {
     );
   }
 
+  /// Return only the actual deviatoin of measurement data points (filtering out
+  /// interpolated days) within the optional date range from the interpolation.
+  ({Vector times, Vector difference}) measuredDiff({
+    DateTime? from,
+    DateTime? to,
+  }) {
+    final Vector t = timesInRange(from: from, to: to);
+    final Vector m = measurementsInRange(from: from, to: to);
+    final Vector w = weightsInRange(from: from, to: to);
+    final Vector mask = isMeasurementInRange(from: from, to: to);
+
+    bool isMeasured(double _, int i) => mask[i] == 1;
+
+    return (
+      times: t.filterElements(isMeasured),
+      difference: (w - m).filterElements(isMeasured),
+    );
+  }
+
   // ---------------------------------------------------------------------------
   // Internal interpolation helpers
   // ---------------------------------------------------------------------------

--- a/app/lib/core/measurementInterpolation.dart
+++ b/app/lib/core/measurementInterpolation.dart
@@ -534,6 +534,15 @@ class MeasurementInterpolationBaseclass {
   Vector get _weightsGaussianExtrapol =>
       __weightsGaussianExtrapol ??= _gaussianInterpolation(_weightsLinExtrapol);
 
+  /// convert display idx to internal idx (returns null if out of range)
+  int? _idxDisplayToInternal(int idxDisplay) {
+    final int idxInternal = idxDisplay + _offsetInDays - _offsetInDaysShown;
+    if (idxInternal < 0 || idxInternal >= _n) {
+      return null;
+    }
+    return idxInternal;
+  }
+
   // ---------------------------------------------------------------------------
   // Public API — display-length vectors
   // ---------------------------------------------------------------------------
@@ -556,7 +565,7 @@ class MeasurementInterpolationBaseclass {
       final Vector weightsExtrapol =
           Vector.fromList(<double>[
             for (int idx = 1; idx <= _offsetInDaysShown; idx++)
-              finalSlope * idx,
+              _finalSlope * idx,
           ]) +
           weightsLinear.last;
 
@@ -765,6 +774,23 @@ class MeasurementInterpolationBaseclass {
   double _slope(int idxFrom, int idxTo, Vector w) =>
       w.isNotEmpty ? (w[idxTo] - w[idxFrom]) / (idxTo - idxFrom) : 0;
 
+  /// first derivative of gaussian Interpolation. Internal idx!
+  double _derivative(int idx) {
+    // check if idx + 2 and idx- 2 are in range
+    if (idx - 2 >= 0 && idx + 2 < _n) {
+      return (1 * _weightsGaussianExtrapol[idx - 2] -
+              8 * _weightsGaussianExtrapol[idx - 1] +
+              8 * _weightsGaussianExtrapol[idx + 1] -
+              1 * _weightsGaussianExtrapol[idx + 2]) /
+          12;
+    } else if (idx - 1 >= 0 && idx + 1 < _n) {
+      return (_weightsGaussianExtrapol[idx - 1] -
+              _weightsGaussianExtrapol[idx + 1]) /
+          2;
+    }
+    return 0;
+  }
+
   Vector _gaussianInterpolation(Vector w) => Vector.fromList(<double>[
     for (final int idx in _timesIdx)
       (w[idx] != 0) ? _gaussianMean(_times[idx], w) : 0,
@@ -775,8 +801,19 @@ class MeasurementInterpolationBaseclass {
   // ---------------------------------------------------------------------------
 
   /// Final slope of extrapolation [kg/day].
-  double get finalSlope =>
-      _slope(_idxLast, _idxLast + _offsetInDaysShown, _weightsGaussianExtrapol);
+  double get _finalSlope => _derivative(_idxLast);
+  // _slope(_idxLast, _idxLast + _offsetInDaysShown, _weightsGaussianExtrapol);
+
+  /// get slope of display weights at [day]
+  double slopeAtDay(DateTime day) {
+    final int? idx = indexForDay(day);
+    final int? idxInternal = idx != null ? _idxDisplayToInternal(idx) : null;
+    if (idxInternal == null) {
+      return 0;
+    }
+
+    return _derivative(idxInternal);
+  }
 
   /// Return the index into display vectors for a given [day], or null
   /// if [day] falls outside the display range.

--- a/app/lib/core/measurementStats.dart
+++ b/app/lib/core/measurementStats.dart
@@ -6,6 +6,7 @@ import 'package:ml_linalg/linalg.dart';
 import 'package:ml_linalg/vector.dart';
 import 'package:provider/provider.dart';
 
+import 'package:trale/core/measurement.dart';
 import 'package:trale/core/measurementDatabase.dart';
 import 'package:trale/core/measurementInterpolation.dart';
 import 'package:trale/core/preferences.dart';
@@ -23,7 +24,7 @@ class MeasurementStats {
   /// singleton instance
   static final MeasurementStats _instance = MeasurementStats._internal();
 
-  /// get measurements
+  /// get measurementbase
   MeasurementDatabase get db => MeasurementDatabase();
 
   /// get interpolation
@@ -181,6 +182,76 @@ class MeasurementStats {
   /// get frequency of taking measurements (all time) [/week]
   double? get globalFrequency =>
       7 * globalNMeasurements / (globalDeltaTime.inDays + 1);
+
+  /// get global max weight with date
+  ({double? weight, DateTime? date}) get globalMaxWeightDate {
+    if (db.nMeasurements == 0) {
+      return (weight: null, date: null);
+    }
+    Measurement currentMax = db.measurements.first;
+    for (final Measurement m in db.measurements) {
+      if (m.weight > currentMax.weight) {
+        currentMax = m;
+      }
+    }
+    return (weight: currentMax.weight, date: currentMax.date);
+  }
+
+  /// get global min weight with date
+  ({double? weight, DateTime? date}) get globalMinWeightDate {
+    if (db.nMeasurements == 0) {
+      return (weight: null, date: null);
+    }
+    Measurement currentMin = db.measurements.first;
+    for (final Measurement m in db.measurements) {
+      if (m.weight <= currentMin.weight) {
+        currentMin = m;
+      }
+    }
+    return (weight: currentMin.weight, date: currentMin.date);
+  }
+
+  /// get global interpolated max weight with date
+  ({double? weight, DateTime? date}) get globalMaxInterpolatedWeightDate {
+    if (db.nMeasurements == 0) {
+      return (weight: null, date: null);
+    }
+    final Vector weights = ip.measurementsInRange(
+      from: db.firstDate,
+      to: DateTime.now(),
+    );
+    final Vector dates = ip.timesInRange(
+      from: db.firstDate,
+      to: DateTime.now(),
+    );
+    // get where weights is max
+    final int maxIndex = weights.argmax();
+    return (
+      weight: weights[maxIndex],
+      date: DateTime.fromMillisecondsSinceEpoch(dates[maxIndex].round()),
+    );
+  }
+
+  /// get global interpolated min weight with date
+  ({double? weight, DateTime? date}) get globalMinInterpolatedWeightDate {
+    if (db.nMeasurements == 0) {
+      return (weight: null, date: null);
+    }
+    final Vector weights = ip.measurementsInRange(
+      from: db.firstDate,
+      to: DateTime.now(),
+    );
+    final Vector dates = ip.timesInRange(
+      from: db.firstDate,
+      to: DateTime.now(),
+    );
+    // get where weights is min
+    final int minIndex = weights.argmin();
+    return (
+      weight: weights[minIndex],
+      date: DateTime.fromMillisecondsSinceEpoch(dates[minIndex].round()),
+    );
+  }
 
   // ---- Shared helpers ----
 
@@ -346,14 +417,25 @@ class MeasurementStats {
   /// get forecast weight in 1 month [kg], extrapolated from today's slope
   double? get weightInOneMonth => weightInNDays(30);
 
-  /// get standard deviation of measurements in stats range
-  double? standardDeviationLastNDays(int nDays) {
-    final Vector measurementsLastNDays = ip.measurementsInRange(
-      from: toDate.subtract(Duration(days: nDays)),
-      to: toDate,
-    );
-    return measurementsLastNDays.std();
+  /// get standard deviation from interpolation
+  double? stdLastNDays(int nDays) {
+    final Vector diff = ip
+        .measuredDiff(
+          from: toDate.subtract(Duration(days: nDays)),
+          to: toDate,
+        )
+        .difference;
+    if (diff.isEmpty) {
+      return null;
+    }
+    return sqrt(diff.pow(2).mean());
   }
+
+  /// get standard deviation from interpolation in last month
+  double? get stdLastMonth => stdLastNDays(30);
+
+  /// get standard deviation from interpolation in last year
+  double? get stdLastYear => stdLastNDays(365);
 
   /// get standard deviation from interpolation in stats range
   double? get std {
@@ -367,12 +449,25 @@ class MeasurementStats {
 
 /// add extension to Vector for standard deviation
 extension VectorStats on Vector {
-  /// get standard deviation of vector
-  double? std() {
-    if (length < 2) {
-      return null;
+  /// get index of max value in vector
+  int argmax() {
+    int maxIndex = 0;
+    for (int i = 1; i < length; i++) {
+      if (this[i] > this[maxIndex]) {
+        maxIndex = i;
+      }
     }
-    final double mean = this.mean();
-    return sqrt((this - mean).pow(2).sum() / (length - 1));
+    return maxIndex;
+  }
+
+  /// get index of min value in vector
+  int argmin() {
+    int minIndex = 0;
+    for (int i = 1; i < length; i++) {
+      if (this[i] <= this[minIndex]) {
+        minIndex = i;
+      }
+    }
+    return minIndex;
   }
 }

--- a/app/lib/core/measurementStats.dart
+++ b/app/lib/core/measurementStats.dart
@@ -43,11 +43,16 @@ class MeasurementStats {
   void init() {}
 
   /// return difference of smoothed weights over last [nDays]
-  double? deltaWeightLastNDays(int nDays) {
-    if (ip.idxLast < nDays) {
+  double? deltaWeightLastNDays(int nDays, {DateTime? from}) {
+    final DateTime fromDate = from ?? DateTime.now();
+    final double? weightFrom = ip.interpolationForDay(fromDate);
+    final double? weightTo = ip.interpolationForDay(
+      fromDate.subtract(Duration(days: nDays)),
+    );
+    if (weightFrom == null || weightTo == null) {
       return null;
     }
-    return ip.weights[ip.idxLast] - ip.weights[ip.idxLast - nDays];
+    return weightFrom - weightTo;
   }
 
   /// get max weight
@@ -168,21 +173,31 @@ class MeasurementStats {
       _deltaWeightLastWeek ??= deltaWeightLastNDays(7);
 
   /// get time of reaching target weight in kg
-  Duration? timeOfTargetWeight(double? targetWeight, bool loose) {
+  Duration? timeOfTargetWeight(
+    double? targetWeight,
+    bool loose, {
+    DateTime? from,
+  }) {
     if ((targetWeight == null) || (db.nMeasurements < 2)) {
       return null;
     }
 
+    DateTime fromDate = from ?? DateTime.now();
+    double? interpolationDate = ip.interpolationForDay(fromDate);
+    // if no interpolation value for fromDate, no prediction
+    if (interpolationDate == null) {
+      return null;
+    }
     // Check if target weight is already completed
     if (loose
-        ? targetWeight > ip.weights[ip.idxLast]
-        : targetWeight <= ip.weights[ip.idxLast]) {
+        ? targetWeight > interpolationDate
+        : targetWeight <= interpolationDate) {
       return const Duration(days: -1);
     }
 
     final double slope = ip.finalSlope;
     // Crossing is in the past
-    if (slope * (ip.weights[ip.idxLast] - targetWeight) >= 0) {
+    if (slope * (interpolationDate - targetWeight) >= 0) {
       return null;
     }
 
@@ -192,7 +207,7 @@ class MeasurementStats {
       return null;
     }
     // in ms from last measurement
-    final int remainingTime = ((targetWeight - ip.weights[ip.idxLast]) / slope)
+    final int remainingTime = ((targetWeight - interpolationDate) / slope)
         .round();
 
     // if remaining time is rounded to 0, return -1
@@ -202,19 +217,6 @@ class MeasurementStats {
 
     return Duration(days: remainingTime);
   }
-
-  /// Return the interpolated weight [kg] for a given [day], or null if [day]
-  /// falls outside the displayed (measured + extrapolated) range.
-  double? interpolationAtDay(DateTime day) {
-    final int? displayIdx = ip.indexForDay(day);
-    if (displayIdx == null) {
-      return null;
-    }
-    return ip.weights[displayIdx];
-  }
-
-  /// Interpolated weight [kg] for today.
-  double? get interpolationToday => interpolationAtDay(DateTime.now());
 
   /// Return the target-weight reference value [kg] for a given [day],
   /// following the "Z"-shaped line used in the line chart.
@@ -258,12 +260,12 @@ class MeasurementStats {
       targetDate.day,
     );
 
-    // Before setDate or after targetDate → constant at targetWeight
+    // Before setDate or after targetDate -> constant at targetWeight
     if (d.compareTo(sd) <= 0 || d.compareTo(td) >= 0) {
       return targetWeight;
     }
 
-    // Between setDate and targetDate → linear interpolation
+    // Between setDate and targetDate -> linear interpolation
     final int totalDays = td.difference(sd).inDays;
     final int elapsedDays = d.difference(sd).inDays;
     return setWeight + (targetWeight - setWeight) * (elapsedDays / totalDays);
@@ -275,7 +277,7 @@ class MeasurementStats {
   /// Positive means above the reference, negative means below.
   /// Returns null when either value is unavailable.
   double? differenceAtDay(DateTime day) {
-    final double? interpolation = interpolationAtDay(day);
+    final double? interpolation = ip.interpolationForDay(day);
     final double? reference = referenceAtDay(day);
     if (interpolation == null || reference == null) {
       return null;

--- a/app/lib/core/measurementStats.dart
+++ b/app/lib/core/measurementStats.dart
@@ -50,6 +50,9 @@ class MeasurementStats {
   /// get number of measurements in stats range
   int get nMeasurements => _measurements.length;
 
+  /// Content-based hash combining date range and interpolation state.
+  int get hashCode => Object.hash(toDate, fromDate, ip.hashCode);
+
   /// re initialize database
   void reinit() {
     _streakList = null;

--- a/app/lib/core/measurementStats.dart
+++ b/app/lib/core/measurementStats.dart
@@ -189,7 +189,7 @@ class MeasurementStats {
       return const Duration(days: -1);
     }
 
-    final double slope = ip.finalSlope;
+    final double slope = ip.slopeAtDay(toDate);
     // Crossing is in the past
     if (slope * (weight - targetWeight) >= 0) {
       return null;
@@ -277,5 +277,8 @@ class MeasurementStats {
   static const double _kcalPerKg = 7700;
 
   /// get daily calorie deficit based on final slope [kcal/day]
-  double get dailyDeficit => ip.finalSlope * _kcalPerKg;
+  double get dailyDeficit => ip.slopeAtDay(toDate) * _kcalPerKg;
+
+  /// get monthly change in weight [kg/month]
+  double get monthlyChange => ip.slopeAtDay(toDate) * 30;
 }

--- a/app/lib/core/measurementStats.dart
+++ b/app/lib/core/measurementStats.dart
@@ -6,6 +6,7 @@ import 'package:provider/provider.dart';
 
 import 'package:trale/core/measurementDatabase.dart';
 import 'package:trale/core/measurementInterpolation.dart';
+import 'package:trale/core/preferences.dart';
 import 'package:trale/core/traleNotifier.dart';
 
 /// class providing an API to handle interpolation of measurements
@@ -41,23 +42,22 @@ class MeasurementStats {
   /// initialize database
   void init() {}
 
-  /// return difference of Gaussian smoothed weights
+  /// return difference of smoothed weights over last [nDays]
   double? deltaWeightLastNDays(int nDays) {
-    if (ip.measuredTimeSpan < nDays) {
+    if (ip.idxLast < nDays) {
       return null;
     }
-    return ip.weightsGaussianExtrapol[ip.idxLast] -
-        ip.weightsGaussianExtrapol[ip.idxLast - nDays];
+    return ip.weights[ip.idxLast] - ip.weights[ip.idxLast - nDays];
   }
 
   /// get max weight
-  double? get maxWeight => ip.weightsMeasured.max();
+  double? get maxWeight => ip.measured().measurements.max();
 
   /// get min weight
-  double? get minWeight => ip.weightsMeasured.min();
+  double? get minWeight => ip.measured().measurements.min();
 
-  /// get min weight
-  double? get meanWeight => ip.weightsMeasured.mean();
+  /// get mean weight
+  double? get meanWeight => ip.measured().measurements.mean();
 
   /// get current BMI
   double? currentBMI(BuildContext context) {
@@ -68,20 +68,20 @@ class MeasurementStats {
     if (notifier.userHeight == null) {
       return null;
     }
-    return ip.weightsMeasured.last /
+    return ip.measured().measurements.last /
         (notifier.userHeight! * notifier.userHeight! * 0.0001);
   }
 
   /// get total change in weight
   double? get deltaWeight =>
-      maxWeight == null ? null : maxWeight! - ip.weightsMeasured.last;
+      maxWeight == null ? null : maxWeight! - ip.measured().measurements.last;
 
   /// the start of the first measurement until now
   /// get time of records
   Duration get deltaTime => DateTime.now().difference(db.firstDate);
 
   /// get number of measurements
-  int get nMeasurements => ip.nMeasurements;
+  int get nMeasurements => db.nMeasurements;
 
   /// get current streak
   Duration get currentStreak => db.lastDate.sameDay(DateTime.now())
@@ -117,7 +117,7 @@ class MeasurementStats {
 
     /// count number of measurements in the last n days
     int numberOfMeasurements = 0;
-    for (final double time in ip.timesMeasured.toList()) {
+    for (final double time in ip.measured().times.toList()) {
       if (time >= startingTime) {
         numberOfMeasurements += 1;
       }
@@ -175,14 +175,14 @@ class MeasurementStats {
 
     // Check if target weight is already completed
     if (loose
-        ? targetWeight > ip.weightsDisplay[ip.idxLastDisplay]
-        : targetWeight <= ip.weightsDisplay[ip.idxLastDisplay]) {
+        ? targetWeight > ip.weights[ip.idxLast]
+        : targetWeight <= ip.weights[ip.idxLast]) {
       return const Duration(days: -1);
     }
 
     final double slope = ip.finalSlope;
     // Crossing is in the past
-    if (slope * (ip.weightsDisplay[ip.idxLastDisplay] - targetWeight) >= 0) {
+    if (slope * (ip.weights[ip.idxLast] - targetWeight) >= 0) {
       return null;
     }
 
@@ -192,8 +192,8 @@ class MeasurementStats {
       return null;
     }
     // in ms from last measurement
-    final int remainingTime =
-        ((targetWeight - ip.weightsDisplay[ip.idxLastDisplay]) / slope).round();
+    final int remainingTime = ((targetWeight - ip.weights[ip.idxLast]) / slope)
+        .round();
 
     // if remaining time is rounded to 0, return -1
     if (remainingTime == 0) {
@@ -201,5 +201,85 @@ class MeasurementStats {
     }
 
     return Duration(days: remainingTime);
+  }
+
+  /// Return the interpolated weight [kg] for a given [day], or null if [day]
+  /// falls outside the displayed (measured + extrapolated) range.
+  double? interpolationAtDay(DateTime day) {
+    final int? displayIdx = ip.indexForDay(day);
+    if (displayIdx == null) {
+      return null;
+    }
+    return ip.weights[displayIdx];
+  }
+
+  /// Interpolated weight [kg] for today.
+  double? get interpolationToday => interpolationAtDay(DateTime.now());
+
+  /// Return the target-weight reference value [kg] for a given [day],
+  /// following the "Z"-shaped line used in the line chart.
+  ///
+  /// * Before [setDate]: constant at [targetWeight].
+  /// * Between [setDate] and [targetDate]: linear from [setWeight] to
+  ///   [targetWeight].
+  /// * After [targetDate]: constant at [targetWeight].
+  ///
+  /// Returns null when the target-weight feature is disabled or no target
+  /// weight is set. When no target date is configured, returns a constant
+  /// [targetWeight] for every day.
+  double? referenceAtDay(DateTime day) {
+    final Preferences prefs = Preferences();
+    if (!prefs.targetWeightEnabled) {
+      return null;
+    }
+
+    final double? targetWeight = prefs.userTargetWeight;
+    if (targetWeight == null) {
+      return null;
+    }
+
+    final DateTime? targetDate = prefs.userTargetWeightDate;
+    if (targetDate == null) {
+      return targetWeight;
+    }
+
+    final TraleNotifier notifier = TraleNotifier();
+    final DateTime? setDate = notifier.userTargetWeightSetDate;
+    final double? setWeight = notifier.userTargetWeightSetWeight;
+    if (setDate == null || setWeight == null) {
+      return targetWeight;
+    }
+
+    final DateTime d = DateTime(day.year, day.month, day.day);
+    final DateTime sd = DateTime(setDate.year, setDate.month, setDate.day);
+    final DateTime td = DateTime(
+      targetDate.year,
+      targetDate.month,
+      targetDate.day,
+    );
+
+    // Before setDate or after targetDate → constant at targetWeight
+    if (d.compareTo(sd) <= 0 || d.compareTo(td) >= 0) {
+      return targetWeight;
+    }
+
+    // Between setDate and targetDate → linear interpolation
+    final int totalDays = td.difference(sd).inDays;
+    final int elapsedDays = d.difference(sd).inDays;
+    return setWeight + (targetWeight - setWeight) * (elapsedDays / totalDays);
+  }
+
+  /// Return the difference between the interpolated weight and the
+  /// target-weight reference for a given [day].
+  ///
+  /// Positive means above the reference, negative means below.
+  /// Returns null when either value is unavailable.
+  double? differenceAtDay(DateTime day) {
+    final double? interpolation = interpolationAtDay(day);
+    final double? reference = referenceAtDay(day);
+    if (interpolation == null || reference == null) {
+      return null;
+    }
+    return interpolation - reference;
   }
 }

--- a/app/lib/core/measurementStats.dart
+++ b/app/lib/core/measurementStats.dart
@@ -311,4 +311,23 @@ class MeasurementStats {
 
   /// get monthly change in weight [kg/month]
   double get monthlyChange => ip.slopeAtDay(toDate) * 30;
+
+  /// get interpolated weight today [kg]
+  double? get weightToday => ip.interpolationForDay(toDate);
+
+  /// get forecast weight in n days [kg], extrapolated from today's slope
+  double? weightInNDays(int nDays) {
+    final double? today = weightToday;
+    final double? slope = ip.slopeAtDay(toDate);
+    if (today == null || slope == null) {
+      return null;
+    }
+    return today + slope * nDays;
+  }
+
+  /// get forecast weight in 1 week [kg], extrapolated from today's slope
+  double? get weightInOneWeek => weightInNDays(7);
+
+  /// get forecast weight in 1 month [kg], extrapolated from today's slope
+  double? get weightInOneMonth => weightInNDays(30);
 }

--- a/app/lib/core/measurementStats.dart
+++ b/app/lib/core/measurementStats.dart
@@ -110,6 +110,64 @@ class MeasurementStats {
   /// get min interpolated weight in stats range
   double? get minInterpolatedWeight => weights.min();
 
+  /// get max measured weight with date in stats range
+  ({double? weight, DateTime? date}) get maxWeightDate {
+    if (nMeasurements == 0) {
+      return (weight: null, date: null);
+    }
+    final ({Vector times, Vector measurements}) data = ip.measured(
+      from: _dates.from,
+      to: _dates.to,
+    );
+    final int maxIndex = data.measurements.argmax();
+    return (
+      weight: data.measurements[maxIndex],
+      date: DateTime.fromMillisecondsSinceEpoch(data.times[maxIndex].round()),
+    );
+  }
+
+  /// get min measured weight with date in stats range
+  ({double? weight, DateTime? date}) get minWeightDate {
+    if (nMeasurements == 0) {
+      return (weight: null, date: null);
+    }
+    final ({Vector times, Vector measurements}) data = ip.measured(
+      from: _dates.from,
+      to: _dates.to,
+    );
+    final int minIndex = data.measurements.argmin();
+    return (
+      weight: data.measurements[minIndex],
+      date: DateTime.fromMillisecondsSinceEpoch(data.times[minIndex].round()),
+    );
+  }
+
+  /// get max interpolated weight with date in stats range
+  ({double? weight, DateTime? date}) get maxInterpolatedWeightDate {
+    if (nMeasurements == 0) {
+      return (weight: null, date: null);
+    }
+    final Vector dates = ip.timesInRange(from: _dates.from, to: _dates.to);
+    final int maxIndex = weights.argmax();
+    return (
+      weight: weights[maxIndex],
+      date: DateTime.fromMillisecondsSinceEpoch(dates[maxIndex].round()),
+    );
+  }
+
+  /// get min interpolated weight with date in stats range
+  ({double? weight, DateTime? date}) get minInterpolatedWeightDate {
+    if (nMeasurements == 0) {
+      return (weight: null, date: null);
+    }
+    final Vector dates = ip.timesInRange(from: _dates.from, to: _dates.to);
+    final int minIndex = weights.argmin();
+    return (
+      weight: weights[minIndex],
+      date: DateTime.fromMillisecondsSinceEpoch(dates[minIndex].round()),
+    );
+  }
+
   /// get mean weight
   double? get meanWeight => measurements.mean();
 

--- a/app/lib/core/measurementStats.dart
+++ b/app/lib/core/measurementStats.dart
@@ -7,6 +7,7 @@ import 'package:provider/provider.dart';
 import 'package:trale/core/measurementDatabase.dart';
 import 'package:trale/core/measurementInterpolation.dart';
 import 'package:trale/core/preferences.dart';
+import 'package:trale/core/stats_range.dart';
 import 'package:trale/core/traleNotifier.dart';
 
 /// class providing an API to handle interpolation of measurements
@@ -26,12 +27,29 @@ class MeasurementStats {
   /// get interpolation
   MeasurementInterpolation get ip => MeasurementInterpolation();
 
+  /// get stats range setting
+  StatsRange get _statsRange => Preferences().statsRange;
+
+  /// get dates for stats range
+  ({DateTime? from, DateTime? to}) get _statsRangeDates => _statsRange.dates;
+
+  /// get measurements in stats range
+  Vector get _measurementsRangeDates => ip
+      .measured(from: _statsRangeDates.from, to: _statsRangeDates.to)
+      .measurements;
+
+  /// get toDate, default to now if null
+  DateTime get toDate => _statsRangeDates.to ?? DateTime.now();
+
+  /// get fromDate, default to first measurement date if null
+  DateTime get fromDate => _statsRangeDates.from ?? db.firstDate;
+
+  /// get number of measurements in stats range
+  int get nMeasurements => _measurementsRangeDates.length;
+
   /// re initialize database
   void reinit() {
     _streakList = null;
-    _frequencyLastWeek = null;
-    _frequencyLastMonth = null;
-    _frequencyLastYear = null;
     _deltaWeightLastWeek = null;
     _deltaWeightLastMonth = null;
     _deltaWeightLastYear = null;
@@ -43,26 +61,25 @@ class MeasurementStats {
   void init() {}
 
   /// return difference of smoothed weights over last [nDays]
-  double? deltaWeightLastNDays(int nDays, {DateTime? from}) {
-    final DateTime fromDate = from ?? DateTime.now();
-    final double? weightFrom = ip.interpolationForDay(fromDate);
-    final double? weightTo = ip.interpolationForDay(
-      fromDate.subtract(Duration(days: nDays)),
+  double? deltaWeightLastNDays(int nDays) {
+    final double? weight = ip.interpolationForDay(toDate);
+    final double? weightLastN = ip.interpolationForDay(
+      toDate.subtract(Duration(days: nDays)),
     );
-    if (weightFrom == null || weightTo == null) {
+    if (weight == null || weightLastN == null) {
       return null;
     }
-    return weightFrom - weightTo;
+    return weight - weightLastN;
   }
 
   /// get max weight
-  double? get maxWeight => ip.measured().measurements.max();
+  double? get maxWeight => _measurementsRangeDates.max();
 
   /// get min weight
-  double? get minWeight => ip.measured().measurements.min();
+  double? get minWeight => _measurementsRangeDates.min();
 
   /// get mean weight
-  double? get meanWeight => ip.measured().measurements.mean();
+  double? get meanWeight => _measurementsRangeDates.mean();
 
   /// get current BMI
   double? currentBMI(BuildContext context) {
@@ -73,23 +90,29 @@ class MeasurementStats {
     if (notifier.userHeight == null) {
       return null;
     }
-    return ip.measured().measurements.last /
-        (notifier.userHeight! * notifier.userHeight! * 0.0001);
+    final double? weight = ip.interpolationForDay(toDate);
+    if (weight == null) {
+      return null;
+    }
+    return weight / (notifier.userHeight! * notifier.userHeight! * 0.0001);
   }
 
   /// get total change in weight
-  double? get deltaWeight =>
-      maxWeight == null ? null : maxWeight! - ip.measured().measurements.last;
+  double? get deltaWeight {
+    final double? maxWeight = this.maxWeight;
+    final double? weight = ip.interpolationForDay(toDate);
+    if (weight == null || maxWeight == null) {
+      return null;
+    }
+    return maxWeight - weight;
+  }
 
   /// the start of the first measurement until now
   /// get time of records
-  Duration get deltaTime => DateTime.now().difference(db.firstDate);
-
-  /// get number of measurements
-  int get nMeasurements => db.nMeasurements;
+  Duration get deltaTime => toDate.difference(fromDate);
 
   /// get current streak
-  Duration get currentStreak => db.lastDate.sameDay(DateTime.now())
+  Duration get currentStreak => ip.hasMeasurementOnDay(toDate)
       ? Duration(days: streakList.last.round())
       : Duration.zero;
 
@@ -103,7 +126,10 @@ class MeasurementStats {
   Vector _estimateStreakList() {
     int streak = 0;
     final List<int> streakList = <int>[0]; // catch for no measurements
-    for (final double isMS in ip.isMeasurement) {
+    for (final double isMS in ip.isMeasurementInRange(
+      from: fromDate,
+      to: toDate,
+    )) {
       if (isMS.round() == 1) {
         streak++;
       } else if (streak > 0) {
@@ -113,43 +139,6 @@ class MeasurementStats {
     }
     return Vector.fromList(streakList);
   }
-
-  /// get frequency of taking measurements
-  double _getFrequency(int nDays) {
-    final int startingTime = DateTime.now()
-        .subtract(Duration(days: nDays))
-        .millisecondsSinceEpoch;
-
-    /// count number of measurements in the last n days
-    int numberOfMeasurements = 0;
-    for (final double time in ip.measured().times.toList()) {
-      if (time >= startingTime) {
-        numberOfMeasurements += 1;
-      }
-    }
-    // to ensure that the time before the very first measurement is not
-    // biasing the result, use as duration min of nDays or days since first m
-    if (deltaTime.inDays < nDays) {
-      return numberOfMeasurements / deltaTime.inDays;
-    } else {
-      return numberOfMeasurements / nDays;
-    }
-  }
-
-  double? _frequencyLastWeek;
-
-  /// get frequency of taking measurements (last week)
-  double? get frequencyLastWeek => _frequencyLastWeek ??= _getFrequency(7);
-
-  double? _frequencyLastMonth;
-
-  /// get frequency of taking measurements (last month)
-  double? get frequencyLastMonth => _frequencyLastMonth ??= _getFrequency(30);
-
-  double? _frequencyLastYear;
-
-  /// get frequency of taking measurements (last year)
-  double? get frequencyLastYear => _frequencyLastYear ??= _getFrequency(365);
 
   /// get frequency of taking measurements (in total)
   double? get frequencyInTotal => nMeasurements / (deltaTime.inDays + 1);
@@ -173,31 +162,24 @@ class MeasurementStats {
       _deltaWeightLastWeek ??= deltaWeightLastNDays(7);
 
   /// get time of reaching target weight in kg
-  Duration? timeOfTargetWeight(
-    double? targetWeight,
-    bool loose, {
-    DateTime? from,
-  }) {
+  Duration? timeOfTargetWeight(double? targetWeight, bool loose) {
     if ((targetWeight == null) || (db.nMeasurements < 2)) {
       return null;
     }
 
-    DateTime fromDate = from ?? DateTime.now();
-    double? interpolationDate = ip.interpolationForDay(fromDate);
+    final double? weight = ip.interpolationForDay(toDate);
     // if no interpolation value for fromDate, no prediction
-    if (interpolationDate == null) {
+    if (weight == null) {
       return null;
     }
     // Check if target weight is already completed
-    if (loose
-        ? targetWeight > interpolationDate
-        : targetWeight <= interpolationDate) {
+    if (loose ? targetWeight > weight : targetWeight <= weight) {
       return const Duration(days: -1);
     }
 
     final double slope = ip.finalSlope;
     // Crossing is in the past
-    if (slope * (interpolationDate - targetWeight) >= 0) {
+    if (slope * (weight - targetWeight) >= 0) {
       return null;
     }
 
@@ -207,8 +189,7 @@ class MeasurementStats {
       return null;
     }
     // in ms from last measurement
-    final int remainingTime = ((targetWeight - interpolationDate) / slope)
-        .round();
+    final int remainingTime = ((targetWeight - weight) / slope).round();
 
     // if remaining time is rounded to 0, return -1
     if (remainingTime == 0) {
@@ -218,17 +199,12 @@ class MeasurementStats {
     return Duration(days: remainingTime);
   }
 
-  /// Return the target-weight reference value [kg] for a given [day],
-  /// following the "Z"-shaped line used in the line chart.
+  /// Return the target-weight reference value [kg] for a given day
   ///
   /// * Before [setDate]: constant at [targetWeight].
   /// * Between [setDate] and [targetDate]: linear from [setWeight] to
   ///   [targetWeight].
   /// * After [targetDate]: constant at [targetWeight].
-  ///
-  /// Returns null when the target-weight feature is disabled or no target
-  /// weight is set. When no target date is configured, returns a constant
-  /// [targetWeight] for every day.
   double? referenceAtDay(DateTime day) {
     final Preferences prefs = Preferences();
     if (!prefs.targetWeightEnabled) {
@@ -273,9 +249,6 @@ class MeasurementStats {
 
   /// Return the difference between the interpolated weight and the
   /// target-weight reference for a given [day].
-  ///
-  /// Positive means above the reference, negative means below.
-  /// Returns null when either value is unavailable.
   double? differenceAtDay(DateTime day) {
     final double? interpolation = ip.interpolationForDay(day);
     final double? reference = referenceAtDay(day);
@@ -284,4 +257,7 @@ class MeasurementStats {
     }
     return interpolation - reference;
   }
+
+  /// Return the difference between the interpolated weight and the
+  double? get currentDifference => differenceAtDay(toDate);
 }

--- a/app/lib/core/measurementStats.dart
+++ b/app/lib/core/measurementStats.dart
@@ -31,21 +31,24 @@ class MeasurementStats {
   StatsRange get _statsRange => Preferences().statsRange;
 
   /// get dates for stats range
-  ({DateTime? from, DateTime? to}) get _statsRangeDates => _statsRange.dates;
+  ({DateTime? from, DateTime? to}) get _dates => _statsRange.dates;
 
   /// get measurements in stats range
-  Vector get _measurementsRangeDates => ip
-      .measured(from: _statsRangeDates.from, to: _statsRangeDates.to)
-      .measurements;
+  Vector get _measurements =>
+      ip.measured(from: _dates.from, to: _dates.to).measurements;
+
+  /// get weights in stats range
+  Vector get _weights =>
+      ip.measurementsInRange(from: _dates.from, to: _dates.to);
 
   /// get toDate, default to now if null
-  DateTime get toDate => _statsRangeDates.to ?? DateTime.now();
+  DateTime get toDate => _dates.to ?? DateTime.now();
 
   /// get fromDate, default to first measurement date if null
-  DateTime get fromDate => _statsRangeDates.from ?? db.firstDate;
+  DateTime get fromDate => _dates.from ?? db.firstDate;
 
   /// get number of measurements in stats range
-  int get nMeasurements => _measurementsRangeDates.length;
+  int get nMeasurements => _measurements.length;
 
   /// re initialize database
   void reinit() {
@@ -73,13 +76,22 @@ class MeasurementStats {
   }
 
   /// get max weight
-  double? get maxWeight => _measurementsRangeDates.max();
+  double? get maxWeight => _measurements.max();
+
+  /// get max interpolated weight in stats range
+  double? get maxInterpolatedWeight => _weights.max();
 
   /// get min weight
-  double? get minWeight => _measurementsRangeDates.min();
+  double? get minWeight => _measurements.min();
+
+  /// get min interpolated weight in stats range
+  double? get minInterpolatedWeight => _weights.min();
 
   /// get mean weight
-  double? get meanWeight => _measurementsRangeDates.mean();
+  double? get meanWeight => _measurements.mean();
+
+  /// get mean interpolated weight in stats range
+  double? get meanInterpolatedWeight => _weights.mean();
 
   /// get current BMI
   double? currentBMI(BuildContext context) {
@@ -99,7 +111,7 @@ class MeasurementStats {
 
   /// get total change in weight
   double? get deltaWeight {
-    final double? maxWeight = this.maxWeight;
+    final double? maxWeight = maxInterpolatedWeight;
     final double? weight = ip.interpolationForDay(toDate);
     if (weight == null || maxWeight == null) {
       return null;
@@ -260,4 +272,10 @@ class MeasurementStats {
 
   /// Return the difference between the interpolated weight and the
   double? get currentDifference => differenceAtDay(toDate);
+
+  /// kcal per kg of weight change
+  static const double _kcalPerKg = 7700;
+
+  /// get daily calorie deficit based on final slope [kcal/day]
+  double get dailyDeficit => ip.finalSlope * _kcalPerKg;
 }

--- a/app/lib/core/measurementStats.dart
+++ b/app/lib/core/measurementStats.dart
@@ -1,4 +1,6 @@
 // ignore_for_file: file_names
+import 'dart:math';
+
 import 'package:flutter/material.dart';
 import 'package:ml_linalg/linalg.dart';
 import 'package:ml_linalg/vector.dart';
@@ -104,6 +106,12 @@ class MeasurementStats {
 
   /// get mean interpolated weight in stats range
   double? get meanInterpolatedWeight => weights.mean();
+
+  /// get median weight
+  double? get medianWeight => measurements.median();
+
+  /// get median weight
+  double? get medianInterpolatedWeight => weights.median();
 
   /// get current BMI
   double? currentBMI(BuildContext context) {
@@ -318,11 +326,10 @@ class MeasurementStats {
   /// get forecast weight in n days [kg], extrapolated from today's slope
   double? weightInNDays(int nDays) {
     final double? today = weightToday;
-    final double? slope = ip.slopeAtDay(toDate);
-    if (today == null || slope == null) {
+    if (today == null) {
       return null;
     }
-    return today + slope * nDays;
+    return today + ip.slopeAtDay(toDate) * nDays;
   }
 
   /// get forecast weight in 1 week [kg], extrapolated from today's slope
@@ -330,4 +337,27 @@ class MeasurementStats {
 
   /// get forecast weight in 1 month [kg], extrapolated from today's slope
   double? get weightInOneMonth => weightInNDays(30);
+
+  /// get standard deviation of measurements in stats range
+  double? standardDeviationLastNDays(int nDays) {
+    final Vector measurementsLastNDays = ip.measurementsInRange(
+      from: toDate.subtract(Duration(days: nDays)),
+      to: toDate,
+    );
+    return measurementsLastNDays.std();
+  }
+
+  // todo: add std from interpolation
+}
+
+/// add extension to Vector for standard deviation
+extension VectorStats on Vector {
+  /// get standard deviation of vector
+  double? std() {
+    if (length < 2) {
+      return null;
+    }
+    final double mean = this.mean();
+    return sqrt((this - mean).pow(2).sum() / (length - 1));
+  }
 }

--- a/app/lib/core/measurementStats.dart
+++ b/app/lib/core/measurementStats.dart
@@ -280,7 +280,9 @@ class MeasurementStats {
   static const double _kcalPerKg = 7700;
 
   /// get daily calorie deficit based on final slope [kcal/day]
-  double get dailyDeficit => ip.slopeAtDay(toDate) * _kcalPerKg;
+  /// give in precision of 10 kcal/day
+  int get dailyDeficit =>
+      (ip.slopeAtDay(toDate) * _kcalPerKg / 10).round() * 10;
 
   /// get monthly change in weight [kg/month]
   double get monthlyChange => ip.slopeAtDay(toDate) * 30;

--- a/app/lib/core/measurementStats.dart
+++ b/app/lib/core/measurementStats.dart
@@ -33,13 +33,20 @@ class MeasurementStats {
   /// get dates for stats range
   ({DateTime? from, DateTime? to}) get _dates => _statsRange.dates;
 
+  /// cached measurements in stats range
+  Vector? _measurements;
+
   /// get measurements in stats range
-  Vector get _measurements =>
-      ip.measured(from: _dates.from, to: _dates.to).measurements;
+  Vector get measurements => _measurements ??= ip
+      .measured(from: _dates.from, to: _dates.to)
+      .measurements;
+
+  /// cached weights in stats range
+  Vector? _weights;
 
   /// get weights in stats range
-  Vector get _weights =>
-      ip.measurementsInRange(from: _dates.from, to: _dates.to);
+  Vector get weights =>
+      _weights ??= ip.measurementsInRange(from: _dates.from, to: _dates.to);
 
   /// get toDate, default to now if null
   DateTime get toDate => _dates.to ?? DateTime.now();
@@ -48,18 +55,20 @@ class MeasurementStats {
   DateTime get fromDate => _dates.from ?? db.firstDate;
 
   /// get number of measurements in stats range
-  int get nMeasurements => _measurements.length;
+  int get nMeasurements => measurements.length;
 
   /// Content-based hash combining date range and interpolation state.
   int get hashCode => Object.hash(toDate, fromDate, ip.hashCode);
 
   /// re initialize database
   void reinit() {
-    _streakList = null;
+    _globalStreakList = null;
     _deltaWeightLastWeek = null;
     _deltaWeightLastMonth = null;
     _deltaWeightLastYear = null;
-    // recalculate all vectors
+    _measurements = null;
+    _weights = null;
+
     init();
   }
 
@@ -79,22 +88,22 @@ class MeasurementStats {
   }
 
   /// get max weight
-  double? get maxWeight => _measurements.max();
+  double? get maxWeight => measurements.max();
 
   /// get max interpolated weight in stats range
-  double? get maxInterpolatedWeight => _weights.max();
+  double? get maxInterpolatedWeight => weights.max();
 
   /// get min weight
-  double? get minWeight => _measurements.min();
+  double? get minWeight => measurements.min();
 
   /// get min interpolated weight in stats range
-  double? get minInterpolatedWeight => _weights.min();
+  double? get minInterpolatedWeight => weights.min();
 
   /// get mean weight
-  double? get meanWeight => _measurements.mean();
+  double? get meanWeight => measurements.mean();
 
   /// get mean interpolated weight in stats range
-  double? get meanInterpolatedWeight => _weights.mean();
+  double? get meanInterpolatedWeight => weights.mean();
 
   /// get current BMI
   double? currentBMI(BuildContext context) {
@@ -126,25 +135,44 @@ class MeasurementStats {
   /// get time of records
   Duration get deltaTime => toDate.difference(fromDate);
 
-  /// get current streak
-  Duration get currentStreak => ip.hasMeasurementOnDay(toDate)
-      ? Duration(days: streakList.last.round())
+  /// get frequency of taking measurements (in stats range) [/week]
+  double? get frequency => 7 * nMeasurements / (deltaTime.inDays + 1);
+
+  ////////////////////////////////////////////////////////////////////
+  // Global stats (always computed over the full measurement range) //
+  ////////////////////////////////////////////////////////////////////
+
+  /// get total number of measurements (all time)
+  int get globalNMeasurements => db.nMeasurements;
+
+  /// the start of the first measurement until now (all time)
+  Duration get globalDeltaTime => DateTime.now().difference(db.firstDate);
+
+  Vector? _globalStreakList;
+
+  /// get list of all streaks (all time)
+  Vector get globalStreakList => _globalStreakList ??= _estimateStreakList();
+
+  /// get current streak (all time)
+  Duration get globalCurrentStreak => ip.hasMeasurementOnDay(DateTime.now())
+      ? Duration(days: globalStreakList.last.round())
       : Duration.zero;
 
-  /// get max streak
-  Duration get maxStreak => Duration(days: streakList.max().round());
+  /// get max streak (all time)
+  Duration get globalMaxStreak =>
+      Duration(days: globalStreakList.max().round());
 
-  Vector? _streakList;
+  /// get frequency of taking measurements (all time) [/week]
+  double? get globalFrequency =>
+      7 * globalNMeasurements / (globalDeltaTime.inDays + 1);
 
-  /// get list of all streaks
-  Vector get streakList => _streakList ??= _estimateStreakList();
+  // ---- Shared helpers ----
+
+  /// Estimate streak list for a given date range.
   Vector _estimateStreakList() {
     int streak = 0;
     final List<int> streakList = <int>[0]; // catch for no measurements
-    for (final double isMS in ip.isMeasurementInRange(
-      from: fromDate,
-      to: toDate,
-    )) {
+    for (final double isMS in ip.isMeasurement) {
       if (isMS.round() == 1) {
         streak++;
       } else if (streak > 0) {
@@ -154,9 +182,6 @@ class MeasurementStats {
     }
     return Vector.fromList(streakList);
   }
-
-  /// get frequency of taking measurements (in total) [/week]
-  double? get frequency => 7 * nMeasurements / (deltaTime.inDays + 1);
 
   double? _deltaWeightLastYear;
 

--- a/app/lib/core/measurementStats.dart
+++ b/app/lib/core/measurementStats.dart
@@ -56,7 +56,7 @@ class MeasurementStats {
 
   /// get weights in stats range
   Vector get weights =>
-      _weights ??= ip.measurementsInRange(from: _dates.from, to: _dates.to);
+      _weights ??= ip.weightsInRange(from: _dates.from, to: _dates.to);
 
   /// get toDate, default to now if null
   DateTime get toDate => _dates.to ?? DateTime.now();

--- a/app/lib/core/measurementStats.dart
+++ b/app/lib/core/measurementStats.dart
@@ -43,6 +43,13 @@ class MeasurementStats {
       .measured(from: _dates.from, to: _dates.to)
       .measurements;
 
+  /// cached diff in stats range
+  Vector? _diff;
+
+  /// get measurements in stats range
+  Vector get diff =>
+      _diff ??= ip.measuredDiff(from: _dates.from, to: _dates.to).difference;
+
   /// cached weights in stats range
   Vector? _weights;
 
@@ -70,6 +77,7 @@ class MeasurementStats {
     _deltaWeightLastYear = null;
     _measurements = null;
     _weights = null;
+    _diff = null;
 
     init();
   }
@@ -347,7 +355,14 @@ class MeasurementStats {
     return measurementsLastNDays.std();
   }
 
-  // todo: add std from interpolation
+  /// get standard deviation from interpolation in stats range
+  double? get std {
+    final Vector diff = this.diff;
+    if (diff.isEmpty) {
+      return null;
+    }
+    return sqrt(diff.pow(2).mean());
+  }
 }
 
 /// add extension to Vector for standard deviation

--- a/app/lib/core/measurementStats.dart
+++ b/app/lib/core/measurementStats.dart
@@ -155,8 +155,8 @@ class MeasurementStats {
     return Vector.fromList(streakList);
   }
 
-  /// get frequency of taking measurements (in total)
-  double? get frequencyInTotal => nMeasurements / (deltaTime.inDays + 1);
+  /// get frequency of taking measurements (in total) [/week]
+  double? get frequency => 7 * nMeasurements / (deltaTime.inDays + 1);
 
   double? _deltaWeightLastYear;
 

--- a/app/lib/core/measurementStats.dart
+++ b/app/lib/core/measurementStats.dart
@@ -216,7 +216,7 @@ class MeasurementStats {
     if (db.nMeasurements == 0) {
       return (weight: null, date: null);
     }
-    final Vector weights = ip.measurementsInRange(
+    final Vector weights = ip.weightsInRange(
       from: db.firstDate,
       to: DateTime.now(),
     );
@@ -237,7 +237,7 @@ class MeasurementStats {
     if (db.nMeasurements == 0) {
       return (weight: null, date: null);
     }
-    final Vector weights = ip.measurementsInRange(
+    final Vector weights = ip.weightsInRange(
       from: db.firstDate,
       to: DateTime.now(),
     );

--- a/app/lib/core/preferences.dart
+++ b/app/lib/core/preferences.dart
@@ -59,6 +59,9 @@ class Preferences {
   /// default for statsRangeTo
   final DateTime? defaultStatsRangeTo = null;
 
+  /// default for stats use interpolation (true = interpolated, false = raw)
+  final bool defaultStatsUseInterpolation = true;
+
   /// default for userTargetWeight in kg
   final double defaultUserWeight = 70;
 
@@ -126,6 +129,9 @@ class Preferences {
 
   /// default show measurement hint banner
   final bool defaultShowMeasurementHintBanner = true;
+
+  /// default show stats hint banner
+  final bool defaultShowStatsHintBanner = true;
 
   /// default show changelog
   final bool defaultShowChangelog = true;
@@ -210,6 +216,13 @@ class Preferences {
     final DateTime parsed = DateTime.parse(raw);
     return parsed.millisecondsSinceEpoch == 0 ? null : parsed;
   }
+
+  /// Get stats use interpolation
+  bool get statsUseInterpolation => prefs.getBool('statsUseInterpolation')!;
+
+  /// Set stats use interpolation
+  set statsUseInterpolation(bool useInterpolation) =>
+      prefs.setBool('statsUseInterpolation', useInterpolation);
 
   /// Get statsRangeFrom
   DateTime? get statsRangeFrom {
@@ -384,6 +397,13 @@ class Preferences {
   set showMeasurementHintBanner(bool show) =>
       prefs.setBool('showMeasurementHintBanner', show);
 
+  /// Get show stats hint banner
+  bool get showStatsHintBanner => prefs.getBool('showStatsHintBanner')!;
+
+  /// Set show stats hint banner
+  set showStatsHintBanner(bool show) =>
+      prefs.setBool('showStatsHintBanner', show);
+
   /// Get show changelog
   bool get showChangelog => prefs.getBool('showChangelog')!;
 
@@ -511,6 +531,9 @@ class Preferences {
     if (override || !prefs.containsKey('showMeasurementHintBanner')) {
       showMeasurementHintBanner = defaultShowMeasurementHintBanner;
     }
+    if (override || !prefs.containsKey('showStatsHintBanner')) {
+      showStatsHintBanner = defaultShowStatsHintBanner;
+    }
     if (override || !prefs.containsKey('showChangelog')) {
       showChangelog = defaultShowChangelog;
     }
@@ -537,6 +560,9 @@ class Preferences {
     }
     if (override || !prefs.containsKey('statsRangeTo')) {
       statsRangeTo = defaultStatsRangeTo;
+    }
+    if (override || !prefs.containsKey('statsUseInterpolation')) {
+      statsUseInterpolation = defaultStatsUseInterpolation;
     }
   }
 

--- a/app/lib/core/preferences.dart
+++ b/app/lib/core/preferences.dart
@@ -5,6 +5,7 @@ import 'package:trale/core/firstDay.dart';
 import 'package:trale/core/interpolation.dart';
 import 'package:trale/core/language.dart';
 import 'package:trale/core/printFormat.dart';
+import 'package:trale/core/stats_range.dart';
 import 'package:trale/core/theme.dart';
 import 'package:trale/core/unit_precision.dart';
 import 'package:trale/core/units.dart';
@@ -51,6 +52,12 @@ class Preferences {
 
   /// default for userTargetWeightSetDate (not set)
   final DateTime? defaultUserTargetWeightSetDate = null;
+
+  /// default for statsRangeFrom
+  final DateTime? defaultStatsRangeFrom = null;
+
+  /// default for statsRangeTo
+  final DateTime? defaultStatsRangeTo = null;
 
   /// default for userTargetWeight in kg
   final double defaultUserWeight = 70;
@@ -138,6 +145,9 @@ class Preferences {
   /// default reminder minute
   final int defaultReminderMinute = 0;
 
+  /// default stats Range
+  final StatsRange defaultStatsRange = StatsRange.all;
+
   /// getter and setter for all preferences
   /// set user name
   set userName(String name) => prefs.setString('userName', name);
@@ -200,6 +210,30 @@ class Preferences {
     final DateTime parsed = DateTime.parse(raw);
     return parsed.millisecondsSinceEpoch == 0 ? null : parsed;
   }
+
+  /// Get statsRangeFrom
+  DateTime? get statsRangeFrom {
+    final DateTime parsed = DateTime.parse(prefs.getString('statsRangeFrom')!);
+    return parsed.millisecondsSinceEpoch == 0 ? null : parsed;
+  }
+
+  /// Set statsRangeFrom
+  set statsRangeFrom(DateTime? date) => prefs.setString(
+    'statsRangeFrom',
+    (date ?? DateTime.fromMillisecondsSinceEpoch(0)).toIso8601String(),
+  );
+
+  /// Get statsRangeTo
+  DateTime? get statsRangeTo {
+    final DateTime parsed = DateTime.parse(prefs.getString('statsRangeTo')!);
+    return parsed.millisecondsSinceEpoch == 0 ? null : parsed;
+  }
+
+  /// Set statsRangeTo
+  set statsRangeTo(DateTime? date) => prefs.setString(
+    'statsRangeTo',
+    (date ?? DateTime.fromMillisecondsSinceEpoch(0)).toIso8601String(),
+  );
 
   /// set if onboarding screen is shown
   set showOnBoarding(bool show) => prefs.setBool('showOnBoarding', show);
@@ -394,6 +428,12 @@ class Preferences {
   /// Set reminder minute
   set reminderMinute(int minute) => prefs.setInt('reminderMinute', minute);
 
+  /// Get stats range
+  StatsRange get statsRange => prefs.getString('statsRange')!.toStatsRange()!;
+
+  /// Set stats range
+  set statsRange(StatsRange range) => prefs.setString('statsRange', range.name);
+
   /// set default settings /or reset to default
   void loadDefaultSettings({bool override = false}) {
     if (override || !prefs.containsKey('nightMode')) {
@@ -488,6 +528,15 @@ class Preferences {
     }
     if (override || !prefs.containsKey('reminderMinute')) {
       reminderMinute = defaultReminderMinute;
+    }
+    if (override || !prefs.containsKey('statsRange')) {
+      statsRange = defaultStatsRange;
+    }
+    if (override || !prefs.containsKey('statsRangeFrom')) {
+      statsRangeFrom = defaultStatsRangeFrom;
+    }
+    if (override || !prefs.containsKey('statsRangeTo')) {
+      statsRangeTo = defaultStatsRangeTo;
     }
   }
 

--- a/app/lib/core/stats_range.dart
+++ b/app/lib/core/stats_range.dart
@@ -1,0 +1,66 @@
+import 'package:flutter/material.dart';
+
+import 'package:trale/core/preferences.dart';
+import 'package:trale/l10n-gen/app_localizations.dart';
+
+/// Enum with all available ranges used for the statistics page
+enum StatsRange {
+  /// all
+  all,
+
+  /// set date
+  sinceTarget,
+
+  /// year
+  lastYear,
+
+  /// custom
+  custom,
+}
+
+/// extend stats range
+extension StatsRangeExtension on StatsRange {
+  /// get international name
+  String nameLong(BuildContext context) => <StatsRange, String>{
+    StatsRange.all: AppLocalizations.of(context)!.all,
+    StatsRange.sinceTarget: AppLocalizations.of(context)!.sinceTarget,
+    StatsRange.lastYear: AppLocalizations.of(context)!.lastYear,
+    StatsRange.custom: AppLocalizations.of(context)!.custom,
+  }[this]!;
+
+  /// get international name
+  ({DateTime? from, DateTime? to}) dates(BuildContext context) {
+    if (this == StatsRange.all) {
+      return (from: null, to: null);
+    } else if (this == StatsRange.sinceTarget) {
+      final Preferences prefs = Preferences();
+      final DateTime? setDate = prefs.defaultUserTargetWeightSetDate;
+      return (from: setDate, to: null);
+    } else if (this == StatsRange.lastYear) {
+      return (
+        from: DateTime.now().subtract(const Duration(days: 365)),
+        to: DateTime.now(),
+      );
+    }
+    // StatsRange.custom
+
+    final Preferences prefs = Preferences();
+    return (from: prefs.defaultStatsRangeFrom, to: prefs.defaultStatsRangeTo);
+  }
+
+  /// get string expression
+  String get name => toString().split('.').last;
+}
+
+/// convert string to stats range
+extension StatsRangeParsing on String {
+  /// convert string to stats range
+  StatsRange? toStatsRange() {
+    for (final StatsRange range in StatsRange.values) {
+      if (this == range.name) {
+        return range;
+      }
+    }
+    return null;
+  }
+}

--- a/app/lib/core/stats_range.dart
+++ b/app/lib/core/stats_range.dart
@@ -34,7 +34,7 @@ extension StatsRangeExtension on StatsRange {
       return (from: null, to: null);
     } else if (this == StatsRange.sinceTarget) {
       final Preferences prefs = Preferences();
-      final DateTime? setDate = prefs.defaultUserTargetWeightSetDate;
+      final DateTime? setDate = prefs.userTargetWeightSetDate;
       return (from: setDate, to: null);
     } else if (this == StatsRange.lastYear) {
       return (

--- a/app/lib/core/stats_range.dart
+++ b/app/lib/core/stats_range.dart
@@ -29,7 +29,7 @@ extension StatsRangeExtension on StatsRange {
   }[this]!;
 
   /// get international name
-  ({DateTime? from, DateTime? to}) dates(BuildContext context) {
+  ({DateTime? from, DateTime? to}) get dates {
     if (this == StatsRange.all) {
       return (from: null, to: null);
     } else if (this == StatsRange.sinceTarget) {

--- a/app/lib/core/theme.dart
+++ b/app/lib/core/theme.dart
@@ -111,6 +111,9 @@ class TraleTheme {
   /// Get inner border radius
   double get innerBorderRadius => 4;
 
+  /// Get bento border radius
+  double get bentoBorderRadius => 32;
+
   /// Border shape
   final RoundedRectangleBorder borderShape = RoundedRectangleBorder(
     borderRadius: BorderRadius.circular(16),
@@ -121,8 +124,16 @@ class TraleTheme {
     borderRadius: BorderRadius.circular(4),
   );
 
+  /// bento shape
+  final RoundedRectangleBorder bentoBorderShape = RoundedRectangleBorder(
+    borderRadius: BorderRadius.circular(32),
+  );
+
   /// Padding value
   final double padding = 16;
+
+  /// Padding bento grid
+  final double bentoPadding = 8;
 
   /// Space value between two elements
   final double space = 2;

--- a/app/lib/core/traleNotifier.dart
+++ b/app/lib/core/traleNotifier.dart
@@ -9,6 +9,7 @@ import 'package:trale/core/interpolation.dart';
 import 'package:trale/core/language.dart';
 import 'package:trale/core/measurementDatabase.dart';
 import 'package:trale/core/measurementInterpolation.dart';
+import 'package:trale/core/measurementStats.dart';
 import 'package:trale/core/preferences.dart';
 import 'package:trale/core/printFormat.dart';
 import 'package:trale/core/stats_range.dart';
@@ -343,6 +344,7 @@ class TraleNotifier with ChangeNotifier {
   set statsRangeFrom(DateTime? newDate) {
     if (statsRangeFrom != newDate) {
       prefs.statsRangeFrom = newDate;
+      MeasurementStats().reinit();
       notifyListeners();
     }
   }
@@ -354,6 +356,7 @@ class TraleNotifier with ChangeNotifier {
   set statsRangeTo(DateTime? newDate) {
     if (statsRangeTo != newDate) {
       prefs.statsRangeTo = newDate;
+      MeasurementStats().reinit();
       notifyListeners();
     }
   }
@@ -365,6 +368,7 @@ class TraleNotifier with ChangeNotifier {
   set statsRange(StatsRange newRange) {
     if (statsRange != newRange) {
       prefs.statsRange = newRange;
+      MeasurementStats().reinit();
       notifyListeners();
     }
   }

--- a/app/lib/core/traleNotifier.dart
+++ b/app/lib/core/traleNotifier.dart
@@ -11,6 +11,7 @@ import 'package:trale/core/measurementDatabase.dart';
 import 'package:trale/core/measurementInterpolation.dart';
 import 'package:trale/core/preferences.dart';
 import 'package:trale/core/printFormat.dart';
+import 'package:trale/core/stats_range.dart';
 import 'package:trale/core/theme.dart';
 import 'package:trale/core/unit_precision.dart';
 import 'package:trale/core/units.dart';
@@ -333,6 +334,39 @@ class TraleNotifier with ChangeNotifier {
       return null;
     }
     return MeasurementInterpolation().measurementForDay(date);
+  }
+
+  /// getter for stats range from date used for StatsRange.custom
+  DateTime? get statsRangeFrom => prefs.statsRangeFrom;
+
+  /// setter for stats range from date used for StatsRange.custom
+  set statsRangeFrom(DateTime? newDate) {
+    if (statsRangeFrom != newDate) {
+      prefs.statsRangeFrom = newDate;
+      notifyListeners();
+    }
+  }
+
+  /// getter for stats range to date used for StatsRange.custom
+  DateTime? get statsRangeTo => prefs.statsRangeTo;
+
+  /// setter for stats range to date used for StatsRange.custom
+  set statsRangeTo(DateTime? newDate) {
+    if (statsRangeTo != newDate) {
+      prefs.statsRangeTo = newDate;
+      notifyListeners();
+    }
+  }
+
+  /// getter for stats range mode
+  StatsRange get statsRange => prefs.statsRange;
+
+  /// setter for stats range mode
+  set statsRange(StatsRange newRange) {
+    if (statsRange != newRange) {
+      prefs.statsRange = newRange;
+      notifyListeners();
+    }
   }
 
   /// get user height in [cm]

--- a/app/lib/core/traleNotifier.dart
+++ b/app/lib/core/traleNotifier.dart
@@ -373,6 +373,18 @@ class TraleNotifier with ChangeNotifier {
     }
   }
 
+  /// getter for stats use interpolation
+  bool get statsUseInterpolation => prefs.statsUseInterpolation;
+
+  /// setter for stats use interpolation
+  set statsUseInterpolation(bool useInterpolation) {
+    if (statsUseInterpolation != useInterpolation) {
+      prefs.statsUseInterpolation = useInterpolation;
+      MeasurementStats().reinit();
+      notifyListeners();
+    }
+  }
+
   /// get user height in [cm]
   double? get userHeight => prefs.userHeight;
 
@@ -447,6 +459,17 @@ class TraleNotifier with ChangeNotifier {
   set showMeasurementHintBanner(bool show) {
     if (show != showMeasurementHintBanner) {
       prefs.showMeasurementHintBanner = show;
+      notifyListeners();
+    }
+  }
+
+  /// getter
+  bool get showStatsHintBanner => prefs.showStatsHintBanner;
+
+  /// setter
+  set showStatsHintBanner(bool show) {
+    if (show != showStatsHintBanner) {
+      prefs.showStatsHintBanner = show;
       notifyListeners();
     }
   }

--- a/app/lib/core/units.dart
+++ b/app/lib/core/units.dart
@@ -59,8 +59,10 @@ extension TraleUnitExtension on TraleUnit {
   }
 
   /// round double to given precision
-  double doubleToPrecision(double val, TraleUnitPrecision tup) =>
-      (val * ticksPerStep).roundToDouble() / (tup.ticksPerStep ?? ticksPerStep);
+  double doubleToPrecision(double val, TraleUnitPrecision tup) {
+    final int tps = tup.ticksPerStep ?? ticksPerStep;
+    return (val * tps).roundToDouble() / tps;
+  }
 
   /// get string expression
   String get name => toString().split('.').last;

--- a/app/lib/core/zoomLevel.dart
+++ b/app/lib/core/zoomLevel.dart
@@ -5,6 +5,9 @@ import 'package:trale/core/measurementInterpolation.dart';
 
 /// zoom level for line chart in [month]
 enum ZoomLevel {
+  /// one month.
+  one,
+
   /// Two months.
   two,
 
@@ -29,6 +32,7 @@ extension ZoomLevelExtension on ZoomLevel {
   /// get the window length in month
   double get _rangeInMilliseconds =>
       <ZoomLevel, int>{
+        ZoomLevel.one: 1,
         ZoomLevel.two: 2,
         ZoomLevel.six: 6,
         ZoomLevel.year: 12,
@@ -47,7 +51,7 @@ extension ZoomLevelExtension on ZoomLevel {
   /// get next zoom level
   ZoomLevel get next {
     if (this == ZoomLevel.all) {
-      return ZoomLevel.two;
+      return ZoomLevel.one;
     }
     return zoomOut;
   }
@@ -70,8 +74,8 @@ extension ZoomLevelExtension on ZoomLevel {
   /// zoom in
   ZoomLevel get zoomIn {
     /// if already at all return all
-    if (this == ZoomLevel.two) {
-      return ZoomLevel.two;
+    if (this == ZoomLevel.one) {
+      return ZoomLevel.one;
     }
     final ZoomLevel nextLevel = ZoomLevel.values[index - 1];
 

--- a/app/lib/l10n/app_en.arb
+++ b/app/lib/l10n/app_en.arb
@@ -559,6 +559,10 @@
     "@mean": {
         "description": "The mathematical quantity (arithmetic mean)"
     },
+    "median": "median",
+    "@median": {
+        "description": "The mathematical quantity (median)"
+    },
     "measurementFrequency": "measurement frequency",
     "@measurementFrequency": {
         "description": "The frequency of measurements, i.e., how often the user measures their weight within a day on average"
@@ -804,5 +808,25 @@
                 "example": "interpolation"
             }
         }
+    },
+    "bmiSevereUnderweight": "Severely underweight",
+    "@bmiSevereUnderweight": {
+        "description": "BMI category label for BMI < 17"
+    },
+    "bmiUnderweight": "Underweight",
+    "@bmiUnderweight": {
+        "description": "BMI category label for BMI 17–18.5"
+    },
+    "bmiNormal": "Normal weight",
+    "@bmiNormal": {
+        "description": "BMI category label for BMI 18.5–25"
+    },
+    "bmiOverweight": "Overweight",
+    "@bmiOverweight": {
+        "description": "BMI category label for BMI 25–30"
+    },
+    "bmiObese": "Obese",
+    "@bmiObese": {
+        "description": "BMI category label for BMI > 30"
     }
 }

--- a/app/lib/l10n/app_en.arb
+++ b/app/lib/l10n/app_en.arb
@@ -27,6 +27,11 @@
     "month": "month",
     "years": "years",
     "year": "year",
+    "today": "today",
+    "weightForecast": "forecast",
+    "@weightForecast": {
+        "description": "Header for the weight forecast card (today, +1 week, +1 month)"
+    },
     "all": "all",
     "@all": {
         "description": "Stats range: use all data"
@@ -90,6 +95,10 @@
     "stats": "Statistics",
     "@stats": {
         "description": "Header for statistics section"
+    },
+    "allTimeStats": "All-time stats",
+    "@allTimeStats": {
+        "description": "Header for all-time statistics section"
     },
     "trale": "trale",
     "@trale": {

--- a/app/lib/l10n/app_en.arb
+++ b/app/lib/l10n/app_en.arb
@@ -757,5 +757,25 @@
     "diffFromTarget": "Diff. from target",
     "@diffFromTarget": {
         "description": "Label for the difference from target weight stat"
+    },
+    "statsRange": "Stats range",
+    "@statsRange": {
+        "description": "Title for the stats date range selector dialog"
+    },
+    "from": "From",
+    "@from": {
+        "description": "Label for the start date in the stats range selector"
+    },
+    "to": "To",
+    "@to": {
+        "description": "Label for the end date in the stats range selector"
+    },
+    "dates": "Dates",
+    "@dates": {
+        "description": "Section title for the date range in the stats range selector"
+    },
+    "customDateHint": "Long press a date to unset it. An unset start date means from the first measurement, an unset end date means until today.",
+    "@customDateHint": {
+        "description": "Hint text explaining custom date range behaviour"
     }
 }

--- a/app/lib/l10n/app_en.arb
+++ b/app/lib/l10n/app_en.arb
@@ -749,5 +749,13 @@
     "reminderNotificationBody": "You haven't logged your weight today yet.",
     "@reminderNotificationBody": {
         "description": "Body text of the reminder notification"
+    },
+    "calorieDeficit": "calorie deficit",
+    "@calorieDeficit": {
+        "description": "Label for the calorie deficit stat"
+    },
+    "diffFromTarget": "Diff. from target",
+    "@diffFromTarget": {
+        "description": "Label for the difference from target weight stat"
     }
 }

--- a/app/lib/l10n/app_en.arb
+++ b/app/lib/l10n/app_en.arb
@@ -786,5 +786,23 @@
     "customDateHint": "Long press a date to unset it. An unset start date means from the first measurement, an unset end date means until today.",
     "@customDateHint": {
         "description": "Hint text explaining custom date range behaviour"
+    },
+    "statsSourceTitle": "Statistics basis",
+    "@statsSourceTitle": {
+        "description": "Title for the stats data source selector (interpolation vs. raw measurements)"
+    },
+    "statsSourceExplanation": "Interpolated values smooth out daily fluctuations caused by hydration, meal timing, and other factors, giving a clearer picture of your true weight trend. Raw measurements reflect exactly what you recorded but can vary considerably from day to day. Using the interpolated curve helps you track real progress rather than short-term noise.",
+    "@statsSourceExplanation": {
+        "description": "Text explaining the difference between using interpolated values vs. raw measurements as the basis for statistics calculations."
+    },
+    "statsHintBanner": "Statistics are based on {sourceName}. You can change this in the personalization settings.",
+    "@statsHintBanner": {
+        "description": "Hint banner on the stats screen telling the user what the stats are based on.",
+        "placeholders": {
+            "sourceName": {
+                "type": "String",
+                "example": "interpolation"
+            }
+        }
     }
 }

--- a/app/lib/l10n/app_en.arb
+++ b/app/lib/l10n/app_en.arb
@@ -27,6 +27,22 @@
     "month": "month",
     "years": "years",
     "year": "year",
+    "all": "all",
+    "@all": {
+        "description": "Stats range: use all data"
+    },
+    "sinceTarget": "since goal",
+    "@sinceTarget": {
+        "description": "Stats range: since target weight was set"
+    },
+    "lastYear": "last year",
+    "@lastYear": {
+        "description": "Stats range: last 365 days"
+    },
+    "custom": "custom",
+    "@custom": {
+        "description": "Stats range: user-selected date range"
+    },
     "never": "never",
     "@never": {
         "description": "Frequency of backup interval"

--- a/app/lib/pages/measurementScreen.dart
+++ b/app/lib/pages/measurementScreen.dart
@@ -62,16 +62,11 @@ class _MeasurementScreen extends State<MeasurementScreen>
   @override
   Widget build(BuildContext context) {
     super.build(context);
-    final MeasurementDatabase database = MeasurementDatabase();
-    final List<SortedMeasurement> measurements = database.sortedMeasurements;
 
     final int animationDurationInMilliseconds = TraleTheme.of(
       context,
     )!.transitionDuration.slow.inMilliseconds;
-    Widget measurementScreen(
-      BuildContext context,
-      AsyncSnapshot<List<Measurement>> snapshot,
-    ) {
+    Widget measurementScreen(BuildContext context) {
       return Scrollbar(
         radius: const Radius.circular(4),
         thickness: 8,
@@ -86,12 +81,11 @@ class _MeasurementScreen extends State<MeasurementScreen>
       );
     }
 
-    Widget measurementScreenWrapper(
-      BuildContext context,
-      AsyncSnapshot<List<Measurement>> snapshot,
-    ) {
+    Widget measurementScreenWrapper(BuildContext context) {
+      final List<SortedMeasurement> measurements =
+          MeasurementDatabase().sortedMeasurements;
       return measurements.isNotEmpty
-          ? measurementScreen(context, snapshot)
+          ? measurementScreen(context)
           : defaultEmptyChart(context: context);
     }
 
@@ -99,9 +93,7 @@ class _MeasurementScreen extends State<MeasurementScreen>
       controller: _replayController,
       child: StreamBuilder<List<Measurement>>(
         stream: _measurementStream,
-        builder:
-            (BuildContext context, AsyncSnapshot<List<Measurement>> snapshot) =>
-                measurementScreenWrapper(context, snapshot),
+        builder: (BuildContext context, _) => measurementScreenWrapper(context),
       ),
     );
   }

--- a/app/lib/pages/overview.dart
+++ b/app/lib/pages/overview.dart
@@ -107,23 +107,18 @@ class _OverviewScreen extends State<OverviewScreen>
       context,
     )!.transitionDuration.slow.inMilliseconds;
 
-    Widget overviewScreen(
-      BuildContext context,
-      AsyncSnapshot<List<Measurement>> snapshot,
-    ) {
-      // Use measurements count as stable key to avoid
-      // recreating widgets on navigation
-      final int measurementCount = snapshot.data?.length ?? 0;
+    Widget overviewScreen(BuildContext context) {
+      final int hash = MeasurementInterpolation().hashCode;
       return Column(
         mainAxisAlignment: MainAxisAlignment.center,
         children: <Widget>[
-          AnimatedStatsWidgets(key: ValueKey<int>(measurementCount)),
+          AnimatedStatsWidgets(key: ValueKey<int>(hash)),
           AnimateInEffect(
             durationInMilliseconds: animationDurationInMilliseconds,
             child: CustomLineChart(
               loadedFirst: loadedFirst,
               ip: ip,
-              key: ValueKey<int>(measurementCount),
+              key: ValueKey<int>(hash),
             ),
           ),
           const SizedBox(height: 80.0),
@@ -131,15 +126,12 @@ class _OverviewScreen extends State<OverviewScreen>
       );
     }
 
-    Widget overviewScreenWrapper(
-      BuildContext context,
-      AsyncSnapshot<List<Measurement>> snapshot,
-    ) {
-      final MeasurementDatabase database = MeasurementDatabase();
-      final List<SortedMeasurement> measurements = database.sortedMeasurements;
+    Widget overviewScreenWrapper(BuildContext context) {
+      final List<SortedMeasurement> measurements =
+          MeasurementDatabase().sortedMeasurements;
 
       return measurements.isNotEmpty
-          ? overviewScreen(context, snapshot)
+          ? overviewScreen(context)
           : defaultEmptyChart(context: context, overviewScreen: true);
     }
 
@@ -147,12 +139,8 @@ class _OverviewScreen extends State<OverviewScreen>
       controller: _replayController,
       child: StreamBuilder<List<Measurement>>(
         stream: _measurementStream,
-        builder:
-            (BuildContext context, AsyncSnapshot<List<Measurement>> snapshot) =>
-                SafeArea(
-                  key: key,
-                  child: overviewScreenWrapper(context, snapshot),
-                ),
+        builder: (BuildContext context, _) =>
+            SafeArea(key: key, child: overviewScreenWrapper(context)),
       ),
     );
   }

--- a/app/lib/pages/settingsPersonalization.dart
+++ b/app/lib/pages/settingsPersonalization.dart
@@ -135,6 +135,72 @@ class _PersonalizationSettingsPageState
         ),
       ),
       SizedBox(height: TraleTheme.of(context)!.padding),
+      Consumer<TraleNotifier>(
+        builder: (BuildContext context, TraleNotifier notifier, _) {
+          final ColorScheme colorScheme = Theme.of(context).colorScheme;
+          return WidgetGroup(
+            title: AppLocalizations.of(context)!.statsSourceTitle,
+            children: <Widget>[
+              RadioGroup<bool>(
+                groupValue: notifier.statsUseInterpolation,
+                onChanged: (bool? value) {
+                  if (value != null) {
+                    notifier.statsUseInterpolation = value;
+                  }
+                },
+                child: Column(
+                  mainAxisSize: MainAxisSize.min,
+                  children: <Widget>[
+                    GroupedRadioListTile<bool>(
+                      color: notifier.statsUseInterpolation
+                          ? colorScheme.primaryContainer
+                          : colorScheme.surfaceContainerLowest,
+                      shape: notifier.statsUseInterpolation
+                          ? const StadiumBorder()
+                          : null,
+                      value: true,
+                      contentPadding: EdgeInsets.symmetric(
+                        horizontal: TraleTheme.of(context)!.padding,
+                      ),
+                      title: Text(
+                        AppLocalizations.of(context)!.interpolation.inCaps,
+                        style: Theme.of(context).textTheme.bodyLarge,
+                      ),
+                    ),
+                    GroupedRadioListTile<bool>(
+                      color: !notifier.statsUseInterpolation
+                          ? colorScheme.primaryContainer
+                          : colorScheme.surfaceContainerLowest,
+                      shape: !notifier.statsUseInterpolation
+                          ? const StadiumBorder()
+                          : null,
+                      value: false,
+                      contentPadding: EdgeInsets.symmetric(
+                        horizontal: TraleTheme.of(context)!.padding,
+                      ),
+                      title: Text(
+                        AppLocalizations.of(context)!.measurements.inCaps,
+                        style: Theme.of(context).textTheme.bodyLarge,
+                      ),
+                    ),
+                  ],
+                ),
+              ),
+            ],
+          );
+        },
+      ),
+      SizedBox(height: 0.5 * TraleTheme.of(context)!.padding),
+      Padding(
+        padding: EdgeInsets.symmetric(
+          horizontal: TraleTheme.of(context)!.padding,
+        ),
+        child: Text(
+          AppLocalizations.of(context)!.statsSourceExplanation,
+          style: Theme.of(context).textTheme.bodyMedium,
+        ),
+      ),
+      SizedBox(height: TraleTheme.of(context)!.padding),
       WidgetGroup(
         title: AppLocalizations.of(context)!.unitTitle,
         children: const <Widget>[

--- a/app/lib/pages/statScreen.dart
+++ b/app/lib/pages/statScreen.dart
@@ -4,6 +4,8 @@ import 'package:provider/provider.dart';
 import 'package:trale/core/font.dart';
 
 import 'package:trale/core/measurement.dart';
+import 'package:trale/l10n-gen/app_localizations.dart';
+import 'package:trale/widget/animate_in_effect.dart';
 import 'package:trale/core/measurementDatabase.dart';
 import 'package:trale/core/measurementStats.dart';
 import 'package:trale/core/theme.dart';
@@ -106,54 +108,65 @@ class _StatsScreen extends State<StatsScreen>
           .clamp(0, maxVal.toInt())
           .toDouble();
 
+      final int animationDurationInMilliseconds = TraleTheme.of(
+        context,
+      )!.transitionDuration.slow.inMilliseconds;
+      final AppLocalizations l10n = AppLocalizations.of(context)!;
+
       return CustomScrollView(
         physics: const NeverScrollableScrollPhysics(),
         cacheExtent: MediaQuery.of(context).size.height,
         slivers: <Widget>[
           SliverToBoxAdapter(
-            child: Padding(
-              padding: EdgeInsets.all(TraleTheme.of(context)!.padding),
-              child: Center(
-                child: Text(
-                  'Stats',
-                  style: Theme.of(context).textTheme.emphasized.displaySmall,
-                  textAlign: TextAlign.center,
+            child: AnimateInEffect(
+              durationInMilliseconds: animationDurationInMilliseconds,
+              child: Padding(
+                padding: EdgeInsets.all(TraleTheme.of(context)!.padding),
+                child: Center(
+                  child: Text(
+                    l10n.stats,
+                    style: Theme.of(context).textTheme.emphasized.displaySmall,
+                    textAlign: TextAlign.center,
+                  ),
                 ),
               ),
             ),
           ),
           SliverToBoxAdapter(
-            child: InkWell(
-              onTap: () => showStatsRangeDialog(context: context),
-              borderRadius: BorderRadius.circular(
-                TraleTheme.of(context)!.padding,
-              ),
-              child: Padding(
-                padding: EdgeInsets.symmetric(
-                  horizontal: 2 * TraleTheme.of(context)!.padding,
+            child: AnimateInEffect(
+              durationInMilliseconds: animationDurationInMilliseconds,
+              child: InkWell(
+                onTap: () => showStatsRangeDialog(context: context),
+                borderRadius: BorderRadius.circular(
+                  TraleTheme.of(context)!.padding,
                 ),
-                child: Row(
-                  children: <Widget>[
-                    Text(
-                      fromStr,
-                      style: Theme.of(context).textTheme.emphasized.bodyLarge,
-                    ),
-                    Expanded(
-                      child: IgnorePointer(
-                        child: RangeSlider(
-                          values: RangeValues(fromVal, toVal),
-                          min: minVal,
-                          max: maxVal,
-                          divisions: maxVal.toInt(),
-                          onChanged: (_) {},
+                child: Padding(
+                  padding: EdgeInsets.symmetric(
+                    horizontal: 3 * TraleTheme.of(context)!.padding,
+                  ),
+                  child: Row(
+                    children: <Widget>[
+                      Text(
+                        fromStr,
+                        style: Theme.of(context).textTheme.emphasized.bodyLarge,
+                      ),
+                      Expanded(
+                        child: IgnorePointer(
+                          child: RangeSlider(
+                            values: RangeValues(fromVal, toVal),
+                            min: minVal,
+                            max: maxVal,
+                            divisions: maxVal.toInt(),
+                            onChanged: (_) {},
+                          ),
                         ),
                       ),
-                    ),
-                    Text(
-                      toStr,
-                      style: Theme.of(context).textTheme.emphasized.bodyLarge,
-                    ),
-                  ],
+                      Text(
+                        toStr,
+                        style: Theme.of(context).textTheme.emphasized.bodyLarge,
+                      ),
+                    ],
+                  ),
                 ),
               ),
             ),
@@ -162,7 +175,25 @@ class _StatsScreen extends State<StatsScreen>
             key: ValueKey<int>(stats.hashCode),
             child: const StatsWidgetsList(),
           ),
-          const SliverToBoxAdapter(child: GlobalStatsWidgetsList()),
+          SliverToBoxAdapter(
+            child: AnimateInEffect(
+              durationInMilliseconds: animationDurationInMilliseconds,
+              child: Padding(
+                padding: EdgeInsets.all(TraleTheme.of(context)!.padding),
+                child: Center(
+                  child: Text(
+                    l10n.allTimeStats,
+                    style: Theme.of(context).textTheme.emphasized.displaySmall,
+                    textAlign: TextAlign.center,
+                  ),
+                ),
+              ),
+            ),
+          ),
+          SliverToBoxAdapter(
+            key: ValueKey<int>(stats.ip.hashCode),
+            child: const GlobalStatsWidgetsList(),
+          ),
         ],
       );
     }

--- a/app/lib/pages/statScreen.dart
+++ b/app/lib/pages/statScreen.dart
@@ -87,10 +87,41 @@ class _StatsScreen extends State<StatsScreen>
           .format(stats.fromDate);
       final String toStr = notifier.dateFormat(context).format(stats.toDate);
 
+      final DateTime dbFirstDate = MeasurementDatabase().firstDate;
+      final DateTime today = DateTime.now();
+      const double minVal = 0;
+      final double maxVal = today
+          .difference(dbFirstDate)
+          .inDays
+          .clamp(1, 1 << 30)
+          .toDouble();
+      final double fromVal = stats.fromDate
+          .difference(dbFirstDate)
+          .inDays
+          .clamp(0, maxVal.toInt())
+          .toDouble();
+      final double toVal = stats.toDate
+          .difference(dbFirstDate)
+          .inDays
+          .clamp(0, maxVal.toInt())
+          .toDouble();
+
       return CustomScrollView(
         physics: const NeverScrollableScrollPhysics(),
         cacheExtent: MediaQuery.of(context).size.height,
         slivers: <Widget>[
+          SliverToBoxAdapter(
+            child: Padding(
+              padding: EdgeInsets.all(TraleTheme.of(context)!.padding),
+              child: Center(
+                child: Text(
+                  'Stats',
+                  style: Theme.of(context).textTheme.emphasized.displaySmall,
+                  textAlign: TextAlign.center,
+                ),
+              ),
+            ),
+          ),
           SliverToBoxAdapter(
             child: InkWell(
               onTap: () => showStatsRangeDialog(context: context),
@@ -99,18 +130,27 @@ class _StatsScreen extends State<StatsScreen>
               ),
               child: Padding(
                 padding: EdgeInsets.symmetric(
-                  horizontal: TraleTheme.of(context)!.padding,
-                  vertical: 0.5 * TraleTheme.of(context)!.padding,
+                  horizontal: 2 * TraleTheme.of(context)!.padding,
                 ),
-                child: Column(
-                  mainAxisAlignment: MainAxisAlignment.center,
+                child: Row(
                   children: <Widget>[
                     Text(
-                      'data from',
-                      style: Theme.of(context).textTheme.displaySmall,
+                      fromStr,
+                      style: Theme.of(context).textTheme.emphasized.bodyLarge,
+                    ),
+                    Expanded(
+                      child: IgnorePointer(
+                        child: RangeSlider(
+                          values: RangeValues(fromVal, toVal),
+                          min: minVal,
+                          max: maxVal,
+                          divisions: maxVal.toInt(),
+                          onChanged: (_) {},
+                        ),
+                      ),
                     ),
                     Text(
-                      '$fromStr  –  $toStr',
+                      toStr,
                       style: Theme.of(context).textTheme.emphasized.bodyLarge,
                     ),
                   ],
@@ -122,6 +162,7 @@ class _StatsScreen extends State<StatsScreen>
             key: ValueKey<int>(stats.hashCode),
             child: const StatsWidgetsList(),
           ),
+          const SliverToBoxAdapter(child: GlobalStatsWidgetsList()),
         ],
       );
     }

--- a/app/lib/pages/statScreen.dart
+++ b/app/lib/pages/statScreen.dart
@@ -1,11 +1,16 @@
 // ignore_for_file: file_names
 import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+import 'package:trale/core/font.dart';
 
 import 'package:trale/core/measurement.dart';
 import 'package:trale/core/measurementDatabase.dart';
 import 'package:trale/core/measurementStats.dart';
+import 'package:trale/core/theme.dart';
+import 'package:trale/core/traleNotifier.dart';
 import 'package:trale/widget/animation_replay_scope.dart';
 import 'package:trale/widget/emptyChart.dart';
+import 'package:trale/widget/statsRangeDialog.dart';
 import 'package:trale/widget/statsWidgetsList.dart';
 
 /// Stats screen widget.
@@ -72,12 +77,49 @@ class _StatsScreen extends State<StatsScreen>
     super.build(context);
 
     Widget statsScreen(BuildContext context) {
+      final MeasurementStats stats = MeasurementStats();
+      final TraleNotifier notifier = Provider.of<TraleNotifier>(
+        context,
+        listen: false,
+      );
+      final String fromStr = notifier
+          .dateFormat(context)
+          .format(stats.fromDate);
+      final String toStr = notifier.dateFormat(context).format(stats.toDate);
+
       return CustomScrollView(
         physics: const NeverScrollableScrollPhysics(),
         cacheExtent: MediaQuery.of(context).size.height,
         slivers: <Widget>[
           SliverToBoxAdapter(
-            key: ValueKey<int>(MeasurementStats().hashCode),
+            child: InkWell(
+              onTap: () => showStatsRangeDialog(context: context),
+              borderRadius: BorderRadius.circular(
+                TraleTheme.of(context)!.padding,
+              ),
+              child: Padding(
+                padding: EdgeInsets.symmetric(
+                  horizontal: TraleTheme.of(context)!.padding,
+                  vertical: 0.5 * TraleTheme.of(context)!.padding,
+                ),
+                child: Column(
+                  mainAxisAlignment: MainAxisAlignment.center,
+                  children: <Widget>[
+                    Text(
+                      'data from',
+                      style: Theme.of(context).textTheme.displaySmall,
+                    ),
+                    Text(
+                      '$fromStr  –  $toStr',
+                      style: Theme.of(context).textTheme.emphasized.bodyLarge,
+                    ),
+                  ],
+                ),
+              ),
+            ),
+          ),
+          SliverToBoxAdapter(
+            key: ValueKey<int>(stats.hashCode),
             child: const StatsWidgetsList(),
           ),
         ],

--- a/app/lib/pages/statScreen.dart
+++ b/app/lib/pages/statScreen.dart
@@ -1,5 +1,8 @@
 // ignore_for_file: file_names
+import 'dart:async';
+
 import 'package:flutter/material.dart';
+import 'package:phosphor_flutter/phosphor_flutter.dart';
 import 'package:provider/provider.dart';
 import 'package:trale/core/font.dart';
 
@@ -27,12 +30,15 @@ class StatsScreen extends StatefulWidget {
 }
 
 class _StatsScreen extends State<StatsScreen>
-    with AutomaticKeepAliveClientMixin {
+    with AutomaticKeepAliveClientMixin, SingleTickerProviderStateMixin {
   final ScrollController scrollController = ScrollController();
   final GlobalKey<ScaffoldState> key = GlobalKey();
   late final Stream<List<Measurement>> _measurementStream;
   final AnimationReplayController _replayController =
       AnimationReplayController();
+
+  Timer? _bannerTimer;
+  late final AnimationController _bannerController;
 
   /// Whether this tab is currently the nearest visible tab.
   bool _isActive = false;
@@ -65,12 +71,43 @@ class _StatsScreen extends State<StatsScreen>
     _isActive = widget.tabController.index == 1;
     _lastAnimValue = widget.tabController.animation?.value ?? 1.0;
     widget.tabController.animation?.addListener(_onTabAnimationTick);
+
+    _bannerController = AnimationController(
+      vsync: this,
+      duration: const Duration(milliseconds: 200),
+    );
+
+    WidgetsBinding.instance.addPostFrameCallback((Duration _) {
+      final TraleNotifier notifier = Provider.of<TraleNotifier>(
+        context,
+        listen: false,
+      );
+      if (!notifier.showStatsHintBanner) {
+        return;
+      }
+      _bannerTimer?.cancel();
+      _bannerTimer = Timer(const Duration(seconds: 3), () {
+        if (!mounted) {
+          return;
+        }
+        _bannerController.forward();
+      });
+    });
+  }
+
+  @override
+  void didChangeDependencies() {
+    super.didChangeDependencies();
+    _bannerController.duration =
+        TraleTheme.of(context)!.transitionDuration.normal;
   }
 
   @override
   void dispose() {
     widget.tabController.animation?.removeListener(_onTabAnimationTick);
     _replayController.dispose();
+    _bannerTimer?.cancel();
+    _bannerController.dispose();
     super.dispose();
   }
 
@@ -117,6 +154,84 @@ class _StatsScreen extends State<StatsScreen>
         physics: const NeverScrollableScrollPhysics(),
         cacheExtent: MediaQuery.of(context).size.height,
         slivers: <Widget>[
+          SliverToBoxAdapter(
+            child: Consumer<TraleNotifier>(
+              builder: (
+                BuildContext ctx,
+                TraleNotifier n,
+                Widget? _,
+              ) {
+                final String sourceName = n.statsUseInterpolation
+                    ? l10n.interpolation
+                    : l10n.measurements;
+                return SizeTransition(
+                  sizeFactor: CurvedAnimation(
+                    parent: _bannerController,
+                    curve: Curves.easeOut,
+                  ),
+                  axisAlignment: -1.0,
+                  child: !n.showStatsHintBanner
+                      ? const SizedBox.shrink()
+                      : Padding(
+                          padding: EdgeInsets.fromLTRB(
+                            TraleTheme.of(ctx)!.padding,
+                            TraleTheme.of(ctx)!.padding,
+                            TraleTheme.of(ctx)!.padding,
+                            0,
+                          ),
+                          child: Dismissible(
+                            key: const Key('stats_hint_banner'),
+                            direction: DismissDirection.horizontal,
+                            onDismissed: (DismissDirection direction) {
+                              n.showStatsHintBanner = false;
+                            },
+                            child: Material(
+                              elevation: 0,
+                              borderRadius: BorderRadius.circular(4),
+                              color: Theme.of(
+                                ctx,
+                              ).colorScheme.inverseSurface,
+                              child: Padding(
+                                padding: EdgeInsets.all(
+                                  TraleTheme.of(ctx)!.padding,
+                                ),
+                                child: Row(
+                                  children: <Widget>[
+                                    Icon(
+                                      PhosphorIconsBold.info,
+                                      color: Theme.of(ctx)
+                                          .colorScheme
+                                          .onInverseSurface,
+                                      size: 20,
+                                    ),
+                                    SizedBox(
+                                      width: TraleTheme.of(ctx)!.padding,
+                                    ),
+                                    Expanded(
+                                      child: Text(
+                                        l10n.statsHintBanner(
+                                          sourceName: sourceName,
+                                        ),
+                                        style: Theme.of(ctx)
+                                            .textTheme
+                                            .bodyMedium!
+                                            .copyWith(
+                                              color: Theme.of(ctx)
+                                                  .colorScheme
+                                                  .onInverseSurface,
+                                            ),
+                                      ),
+                                    ),
+                                  ],
+                                ),
+                              ),
+                            ),
+                          ),
+                        ),
+                );
+              },
+            ),
+          ),
           SliverToBoxAdapter(
             child: AnimateInEffect(
               durationInMilliseconds: animationDurationInMilliseconds,

--- a/app/lib/pages/statScreen.dart
+++ b/app/lib/pages/statScreen.dart
@@ -85,11 +85,9 @@ class _StatsScreen extends State<StatsScreen>
     }
 
     Widget statsScreenWrapper(BuildContext context) {
-      final List<SortedMeasurement> measurements =
-          MeasurementDatabase().sortedMeasurements;
-      return measurements.isNotEmpty
-          ? statsScreen(context)
-          : defaultEmptyChart(context: context);
+      return MeasurementDatabase().isEmpty
+          ? defaultEmptyChart(context: context)
+          : statsScreen(context);
     }
 
     return AnimationReplayScope(

--- a/app/lib/pages/statScreen.dart
+++ b/app/lib/pages/statScreen.dart
@@ -3,6 +3,7 @@ import 'package:flutter/material.dart';
 
 import 'package:trale/core/measurement.dart';
 import 'package:trale/core/measurementDatabase.dart';
+import 'package:trale/core/measurementStats.dart';
 import 'package:trale/widget/animation_replay_scope.dart';
 import 'package:trale/widget/emptyChart.dart';
 import 'package:trale/widget/statsWidgetsList.dart';
@@ -70,25 +71,24 @@ class _StatsScreen extends State<StatsScreen>
   Widget build(BuildContext context) {
     super.build(context);
 
-    Widget statsScreen(
-      BuildContext context,
-      AsyncSnapshot<List<Measurement>> snapshot,
-    ) {
+    Widget statsScreen(BuildContext context) {
       return CustomScrollView(
         physics: const NeverScrollableScrollPhysics(),
         cacheExtent: MediaQuery.of(context).size.height,
-        slivers: const <Widget>[SliverToBoxAdapter(child: StatsWidgetsList())],
+        slivers: <Widget>[
+          SliverToBoxAdapter(
+            key: ValueKey<int>(MeasurementStats().hashCode),
+            child: const StatsWidgetsList(),
+          ),
+        ],
       );
     }
 
-    Widget statsScreenWrapper(
-      BuildContext context,
-      AsyncSnapshot<List<Measurement>> snapshot,
-    ) {
-      final MeasurementDatabase database = MeasurementDatabase();
-      final List<SortedMeasurement> measurements = database.sortedMeasurements;
+    Widget statsScreenWrapper(BuildContext context) {
+      final List<SortedMeasurement> measurements =
+          MeasurementDatabase().sortedMeasurements;
       return measurements.isNotEmpty
-          ? statsScreen(context, snapshot)
+          ? statsScreen(context)
           : defaultEmptyChart(context: context);
     }
 
@@ -96,9 +96,7 @@ class _StatsScreen extends State<StatsScreen>
       controller: _replayController,
       child: StreamBuilder<List<Measurement>>(
         stream: _measurementStream,
-        builder:
-            (BuildContext context, AsyncSnapshot<List<Measurement>> snapshot) =>
-                statsScreenWrapper(context, snapshot),
+        builder: (BuildContext context, _) => statsScreenWrapper(context),
       ),
     );
   }

--- a/app/lib/widget/bento_card.dart
+++ b/app/lib/widget/bento_card.dart
@@ -31,13 +31,15 @@ class BentoCard extends StatelessWidget {
     this.backgroundColor,
     this.delayInMilliseconds = 0,
     this.pillShape = false,
+    this.onTap,
     super.key,
   }) : _mode = _BentoCardMode.custom,
        _label = null,
        _value = null,
+       _sublabel = null,
+       _textColor = null,
        _m3eShape = null,
        _rotateDuration = Duration.zero,
-       _valueFlex = 1,
        _reversed = false;
 
   /// Two centered text rows: a small label on top and a bold value below.
@@ -55,11 +57,13 @@ class BentoCard extends StatelessWidget {
     super.key,
   }) : _mode = _BentoCardMode.text,
        child = null,
+       onTap = null,
        _label = label,
        _value = value,
+       _sublabel = null,
+       _textColor = null,
        _m3eShape = null,
        _rotateDuration = Duration.zero,
-       _valueFlex = 1,
        _reversed = false;
 
   /// Vertical card with a small label and a large emphasized value.
@@ -68,12 +72,13 @@ class BentoCard extends StatelessWidget {
   /// matching the min-weight card pattern. With [reversed] = true the value
   /// is on top (like the max-weight card).
   ///
-  /// [valueFlex] controls the space ratio of the value region (default 2).
+  /// An optional [sublabel] is rendered in small text below everything else.
   const BentoCard.textEmphasized({
     required String label,
     required String value,
-    int valueFlex = 2,
+    String? sublabel,
     bool reversed = false,
+    Color? textColor,
     this.columnSpan = 6,
     this.rowSpan = 2,
     this.backgroundColor,
@@ -82,11 +87,13 @@ class BentoCard extends StatelessWidget {
     super.key,
   }) : _mode = _BentoCardMode.textEmphasized,
        child = null,
+       onTap = null,
        _label = label,
        _value = value,
+       _sublabel = sublabel,
+       _textColor = textColor,
        _m3eShape = null,
        _rotateDuration = Duration.zero,
-       _valueFlex = valueFlex,
        _reversed = reversed;
 
   /// Horizontal card with a label and a large value placed side by side.
@@ -99,8 +106,8 @@ class BentoCard extends StatelessWidget {
   const BentoCard.textInline({
     required String label,
     required String value,
-    int valueFlex = 2,
     bool reversed = false,
+    Color? textColor,
     this.columnSpan = 6,
     this.rowSpan = 2,
     this.backgroundColor,
@@ -109,11 +116,13 @@ class BentoCard extends StatelessWidget {
     super.key,
   }) : _mode = _BentoCardMode.textInline,
        child = null,
+       onTap = null,
        _label = label,
        _value = value,
+       _sublabel = null,
+       _textColor = textColor,
        _m3eShape = null,
        _rotateDuration = Duration.zero,
-       _valueFlex = valueFlex,
        _reversed = reversed;
 
   /// Square card ([span] × [span] grid cells) with a custom child, an
@@ -127,17 +136,19 @@ class BentoCard extends StatelessWidget {
     this.backgroundColor,
     this.delayInMilliseconds = 0,
     this.pillShape = false,
+    this.onTap,
     Shapes? m3eShape,
     Duration rotateDuration = Duration.zero,
     super.key,
   }) : _mode = _BentoCardMode.custom,
        _label = null,
        _value = null,
+       _sublabel = null,
+       _textColor = null,
        columnSpan = span,
        rowSpan = span,
        _m3eShape = m3eShape,
        _rotateDuration = rotateDuration,
-       _valueFlex = 1,
        _reversed = false;
 
   /// Large hero number on top with a subtitle below (vertical layout).
@@ -201,8 +212,13 @@ class BentoCard extends StatelessWidget {
   /// Whether to use a pill (stadium) shape instead of the bento border shape.
   final bool pillShape;
 
-  // -- Private fields set by [BentoCard.shaped] (and [BentoCard.hero]) --
+  /// Optional tap callback. When set, the card becomes tappable.
+  final VoidCallback? onTap;
 
+  /// Optional text color override for label and value in [textInline].
+  final Color? _textColor;
+
+  // -- Private fields set by [BentoCard.shaped] (and [BentoCard.hero]) --
   /// Optional Material 3 Expressive shape.
   ///
   /// When set, overrides [pillShape] and the default bento border shape.
@@ -221,7 +237,7 @@ class BentoCard extends StatelessWidget {
   final _BentoCardMode _mode;
   final String? _label;
   final String? _value;
-  final int _valueFlex;
+  final String? _sublabel;
   final bool _reversed;
 
   // -- Build helpers --
@@ -256,53 +272,76 @@ class BentoCard extends StatelessWidget {
   }
 
   Widget _buildTextEmphasized(BuildContext context) {
-    final Widget labelWidget = AutoSizeText(
-      _label!,
-      style: Theme.of(context).textTheme.bodyLarge!.onSurface(context),
-      maxLines: 2,
-      textAlign: TextAlign.center,
+    final double pad = TraleTheme.of(context)!.padding / 2;
+    final Widget labelWidget = Padding(
+      padding: _reversed
+          ? EdgeInsets.only(left: pad, right: pad, bottom: pad)
+          : EdgeInsets.only(left: pad, right: pad, top: pad),
+      child: AutoSizeText(
+        _label!,
+        style: Theme.of(
+          context,
+        ).textTheme.bodyLarge!.onSurface(context).copyWith(color: _textColor),
+        maxLines: 2,
+        textAlign: TextAlign.center,
+      ),
     );
     final Widget valueWidget = Expanded(
-      child: Align(
-        alignment: Alignment.center,
-        child: AutoSizeText(
-          _value!,
-          style: Theme.of(context).textTheme.emphasized.bodyMedium!
-              .onSurface(context)
-              .copyWith(
-                fontWeight: FontWeight.w700,
-                fontSize: 200,
-                height: 0.7,
-              ),
-          maxLines: 1,
+      child: Padding(
+        padding: _reversed
+            ? EdgeInsets.only(left: pad / 2, right: pad / 2, top: pad / 2)
+            : EdgeInsets.only(left: pad / 2, right: pad / 2, bottom: pad / 2),
+        child: Align(
+          alignment: Alignment.center,
+          child: AutoSizeText(
+            _value!,
+            style: Theme.of(context).textTheme.emphasized.bodyMedium!
+                .onSurface(context)
+                .copyWith(
+                  fontWeight: FontWeight.w700,
+                  fontSize: 200,
+                  height: 0.7,
+                  color: _textColor,
+                ),
+            maxLines: 1,
+          ),
         ),
       ),
     );
-    return Padding(
-      padding: EdgeInsets.all(TraleTheme.of(context)!.padding / 2),
-      child: Column(
-        mainAxisAlignment: MainAxisAlignment.center,
-        children: _reversed
-            ? <Widget>[valueWidget, labelWidget]
-            : <Widget>[labelWidget, valueWidget],
-      ),
+    final List<Widget> children = _reversed
+        ? <Widget>[valueWidget, labelWidget]
+        : <Widget>[labelWidget, valueWidget];
+    if (_sublabel != null) {
+      final Widget sublabelWidget = Padding(
+        padding: _reversed
+            ? EdgeInsets.only(left: pad, right: pad, top: pad)
+            : EdgeInsets.only(left: pad, right: pad, bottom: pad),
+        child: AutoSizeText(
+          _sublabel,
+          style: Theme.of(
+            context,
+          ).textTheme.bodySmall!.onSurface(context).copyWith(color: _textColor),
+          maxLines: 1,
+          textAlign: TextAlign.center,
+        ),
+      );
+      if (_reversed) {
+        children.insert(0, sublabelWidget);
+      } else {
+        children.add(sublabelWidget);
+      }
+    }
+    return Column(
+      mainAxisAlignment: MainAxisAlignment.center,
+      children: children,
     );
   }
 
   Widget _buildTextInline(BuildContext context) {
-    final Widget labelWidget = Expanded(
-      child: Align(
-        alignment: Alignment.center,
-        child: AutoSizeText(
-          _label!,
-          style: Theme.of(context).textTheme.bodyMedium!.copyWith(height: 1.0),
-          maxLines: 2,
-          textAlign: TextAlign.center,
-        ),
-      ),
-    );
+    final TraleTheme theme = TraleTheme.of(context)!;
+    final Color labelColor =
+        _textColor ?? Theme.of(context).colorScheme.onSurface;
     final Widget valueWidget = Expanded(
-      flex: _valueFlex,
       child: Align(
         alignment: Alignment.center,
         child: AutoSizeText(
@@ -310,16 +349,35 @@ class BentoCard extends StatelessWidget {
           style: Theme.of(context).textTheme.emphasized.displayLarge!.copyWith(
             fontWeight: FontWeight.w900,
             fontSize: 200,
+            color: _textColor,
           ),
           maxLines: 1,
         ),
       ),
     );
-    return Row(
-      mainAxisAlignment: MainAxisAlignment.center,
-      children: _reversed
-          ? <Widget>[valueWidget, labelWidget]
-          : <Widget>[labelWidget, valueWidget],
+    return LayoutBuilder(
+      builder: (BuildContext context, BoxConstraints constraints) {
+        final Widget labelWidget = ConstrainedBox(
+          constraints: BoxConstraints(maxWidth: constraints.maxWidth / 2),
+          child: Padding(
+            padding: EdgeInsets.symmetric(horizontal: theme.padding),
+            child: AutoSizeText(
+              _label!,
+              style: Theme.of(
+                context,
+              ).textTheme.bodyMedium!.copyWith(height: 1.0, color: labelColor),
+              maxLines: 2,
+              textAlign: TextAlign.center,
+            ),
+          ),
+        );
+        return Row(
+          mainAxisAlignment: MainAxisAlignment.center,
+          children: _reversed
+              ? <Widget>[valueWidget, labelWidget]
+              : <Widget>[labelWidget, valueWidget],
+        );
+      },
     );
   }
 
@@ -347,39 +405,42 @@ class BentoCard extends StatelessWidget {
     // Content is constrained to the inscribed square of the circle
     // (side = diameter / √2) so text never reaches the oval edge.
     if (_rotateDuration > Duration.zero && _m3eShape != null) {
-      return AnimateInEffect(
-        delayInMilliseconds: delayInMilliseconds,
-        durationInMilliseconds: theme.transitionDuration.slow.inMilliseconds,
-        child: LayoutBuilder(
-          builder: (BuildContext context, BoxConstraints constraints) {
-            final double side = constraints.biggest.shortestSide;
-            final double padding = theme.padding / 2;
-            final double diameter = side - padding * 2;
-            final double innerSide = diameter / math.sqrt2;
-            return Center(
-              child: SizedBox(
-                width: diameter,
-                height: diameter,
-                child: Stack(
-                  alignment: Alignment.center,
-                  children: <Widget>[
-                    _RotatingShape(
-                      shape: _m3eShape,
-                      color: bgColor,
-                      duration: _rotateDuration,
-                    ),
-                    ClipOval(
-                      child: SizedBox(
-                        width: innerSide,
-                        height: innerSide,
-                        child: content,
+      return GestureDetector(
+        onTap: onTap,
+        child: AnimateInEffect(
+          delayInMilliseconds: delayInMilliseconds,
+          durationInMilliseconds: theme.transitionDuration.slow.inMilliseconds,
+          child: LayoutBuilder(
+            builder: (BuildContext context, BoxConstraints constraints) {
+              final double side = constraints.biggest.shortestSide;
+              final double padding = theme.padding / 2;
+              final double diameter = side - padding * 2;
+              final double innerSide = diameter / math.sqrt2;
+              return Center(
+                child: SizedBox(
+                  width: diameter,
+                  height: diameter,
+                  child: Stack(
+                    alignment: Alignment.center,
+                    children: <Widget>[
+                      _RotatingShape(
+                        shape: _m3eShape,
+                        color: bgColor,
+                        duration: _rotateDuration,
                       ),
-                    ),
-                  ],
+                      ClipOval(
+                        child: SizedBox(
+                          width: innerSide,
+                          height: innerSide,
+                          child: content,
+                        ),
+                      ),
+                    ],
+                  ),
                 ),
-              ),
-            );
-          },
+              );
+            },
+          ),
         ),
       );
     }
@@ -387,12 +448,15 @@ class BentoCard extends StatelessWidget {
     return AnimateInEffect(
       delayInMilliseconds: delayInMilliseconds,
       durationInMilliseconds: theme.transitionDuration.slow.inMilliseconds,
-      child: Card(
-        shape: shape,
-        color: bgColor,
-        margin: EdgeInsets.zero,
-        clipBehavior: Clip.hardEdge,
-        child: content,
+      child: GestureDetector(
+        onTap: onTap,
+        child: Card(
+          shape: shape,
+          color: bgColor,
+          margin: EdgeInsets.zero,
+          clipBehavior: Clip.hardEdge,
+          child: content,
+        ),
       ),
     );
   }
@@ -497,11 +561,15 @@ class _RotatingShapeState extends State<_RotatingShape>
   Widget build(BuildContext context) {
     return RotationTransition(
       turns: _controller,
-      child: SizedBox.expand(
-        child: DecoratedBox(
-          decoration: ShapeDecoration(
-            shape: M3EShapeBorder(shape: widget.shape),
-            color: widget.color,
+      child: AnimatedSwitcher(
+        duration: const Duration(milliseconds: 500),
+        child: SizedBox.expand(
+          key: ValueKey<Shapes>(widget.shape),
+          child: DecoratedBox(
+            decoration: ShapeDecoration(
+              shape: M3EShapeBorder(shape: widget.shape),
+              color: widget.color,
+            ),
           ),
         ),
       ),

--- a/app/lib/widget/bento_card.dart
+++ b/app/lib/widget/bento_card.dart
@@ -256,19 +256,13 @@ class BentoCard extends StatelessWidget {
   }
 
   Widget _buildTextEmphasized(BuildContext context) {
-    final Widget labelWidget = Expanded(
-      child: Align(
-        alignment: Alignment.center,
-        child: AutoSizeText(
-          _label!,
-          style: Theme.of(context).textTheme.bodyLarge!.onSurface(context),
-          maxLines: 2,
-          textAlign: TextAlign.center,
-        ),
-      ),
+    final Widget labelWidget = AutoSizeText(
+      _label!,
+      style: Theme.of(context).textTheme.bodyLarge!.onSurface(context),
+      maxLines: 2,
+      textAlign: TextAlign.center,
     );
     final Widget valueWidget = Expanded(
-      flex: _valueFlex,
       child: Align(
         alignment: Alignment.center,
         child: AutoSizeText(

--- a/app/lib/widget/bento_card.dart
+++ b/app/lib/widget/bento_card.dart
@@ -1,0 +1,516 @@
+import 'dart:math' as math;
+import 'package:flutter/material.dart';
+import 'package:flutter_auto_size_text/flutter_auto_size_text.dart';
+import 'package:flutter_m3shapes_extended/flutter_m3shapes_extended.dart';
+import 'package:trale/core/font.dart';
+import 'package:trale/core/theme.dart';
+import 'package:trale/widget/animate_in_effect.dart';
+
+/// The internal layout mode selected by each [BentoCard] constructor.
+enum _BentoCardMode { custom, text, textEmphasized, textInline }
+
+/// A card widget for use within a [BentoGrid].
+///
+/// Specifies how many grid columns ([columnSpan]) and rows ([rowSpan])
+/// the card occupies. The actual pixel size is computed by the parent
+/// [BentoGrid] based on available width, column count, and bento padding.
+///
+/// Named constructors provide common card layouts:
+/// - [BentoCard.new] — fully custom child widget.
+/// - [BentoCard.text] — small label + value text rows.
+/// - [BentoCard.shaped] — custom child with an M3E shape and optional
+///   rotation; always square ([span] × [span] grid cells).
+/// - [BentoCard.hero] — large display number with a subtitle, built on top
+///   of [BentoCard.shaped].
+class BentoCard extends StatelessWidget {
+  /// Default constructor with a custom child widget.
+  const BentoCard({
+    required Widget this.child,
+    this.columnSpan = 6,
+    this.rowSpan = 2,
+    this.backgroundColor,
+    this.delayInMilliseconds = 0,
+    this.pillShape = false,
+    super.key,
+  }) : _mode = _BentoCardMode.custom,
+       _label = null,
+       _value = null,
+       _m3eShape = null,
+       _rotateDuration = Duration.zero,
+       _valueFlex = 1,
+       _reversed = false;
+
+  /// Two centered text rows: a small label on top and a bold value below.
+  ///
+  /// Replaces the old `DefaultStatCard` pattern used by calorie deficit,
+  /// diff-from-target, max-streak, and measurement-frequency cards.
+  const BentoCard.text({
+    required String label,
+    required String value,
+    this.columnSpan = 6,
+    this.rowSpan = 2,
+    this.backgroundColor,
+    this.delayInMilliseconds = 0,
+    this.pillShape = false,
+    super.key,
+  }) : _mode = _BentoCardMode.text,
+       child = null,
+       _label = label,
+       _value = value,
+       _m3eShape = null,
+       _rotateDuration = Duration.zero,
+       _valueFlex = 1,
+       _reversed = false;
+
+  /// Vertical card with a small label and a large emphasized value.
+  ///
+  /// By default ([reversed] = false) the label is above and the value below,
+  /// matching the min-weight card pattern. With [reversed] = true the value
+  /// is on top (like the max-weight card).
+  ///
+  /// [valueFlex] controls the space ratio of the value region (default 2).
+  const BentoCard.textEmphasized({
+    required String label,
+    required String value,
+    int valueFlex = 2,
+    bool reversed = false,
+    this.columnSpan = 6,
+    this.rowSpan = 2,
+    this.backgroundColor,
+    this.delayInMilliseconds = 0,
+    this.pillShape = false,
+    super.key,
+  }) : _mode = _BentoCardMode.textEmphasized,
+       child = null,
+       _label = label,
+       _value = value,
+       _m3eShape = null,
+       _rotateDuration = Duration.zero,
+       _valueFlex = valueFlex,
+       _reversed = reversed;
+
+  /// Horizontal card with a label and a large value placed side by side.
+  ///
+  /// By default ([reversed] = false) the label is on the left and the large
+  /// value on the right (BMI card pattern). With [reversed] = true the value
+  /// is on the left (time-since-first pattern).
+  ///
+  /// [valueFlex] controls the relative width of the value side (default 2).
+  const BentoCard.textInline({
+    required String label,
+    required String value,
+    int valueFlex = 2,
+    bool reversed = false,
+    this.columnSpan = 6,
+    this.rowSpan = 2,
+    this.backgroundColor,
+    this.delayInMilliseconds = 0,
+    this.pillShape = false,
+    super.key,
+  }) : _mode = _BentoCardMode.textInline,
+       child = null,
+       _label = label,
+       _value = value,
+       _m3eShape = null,
+       _rotateDuration = Duration.zero,
+       _valueFlex = valueFlex,
+       _reversed = reversed;
+
+  /// Square card ([span] × [span] grid cells) with a custom child, an
+  /// optional M3E shape background, and optional continuous rotation.
+  ///
+  /// [m3eShape] and [rotateDuration] are exclusive to this constructor and
+  /// [BentoCard.hero], which is built on top of it.
+  const BentoCard.shaped({
+    required Widget this.child,
+    int span = 6,
+    this.backgroundColor,
+    this.delayInMilliseconds = 0,
+    this.pillShape = false,
+    Shapes? m3eShape,
+    Duration rotateDuration = Duration.zero,
+    super.key,
+  }) : _mode = _BentoCardMode.custom,
+       _label = null,
+       _value = null,
+       columnSpan = span,
+       rowSpan = span,
+       _m3eShape = m3eShape,
+       _rotateDuration = rotateDuration,
+       _valueFlex = 1,
+       _reversed = false;
+
+  /// Large hero number on top with a subtitle below (vertical layout).
+  ///
+  /// Built on top of [BentoCard.shaped]: uses a square [span] × [span]
+  /// footprint and supports [m3eShape] and [rotateDuration].
+  ///
+  /// [valueFlex] and [labelFlex] control the space ratio between the
+  /// display number and the subtitle (defaults: 2 and 1).
+  /// [textColor] overrides the automatically derived text color.
+  factory BentoCard.hero({
+    required String label,
+    required String value,
+    Color? textColor,
+    int valueFlex = 2,
+    int labelFlex = 1,
+    int span = 6,
+    Color? backgroundColor,
+    int delayInMilliseconds = 0,
+    bool pillShape = false,
+    Shapes? m3eShape,
+    Duration rotateDuration = Duration.zero,
+    Key? key,
+  }) {
+    return BentoCard.shaped(
+      span: span,
+      backgroundColor: backgroundColor,
+      delayInMilliseconds: delayInMilliseconds,
+      pillShape: pillShape,
+      m3eShape: m3eShape,
+      rotateDuration: rotateDuration,
+      key: key,
+      child: _HeroContent(
+        label: label,
+        value: value,
+        textColor: textColor,
+        valueFlex: valueFlex,
+        labelFlex: labelFlex,
+      ),
+    );
+  }
+
+  // -- Common fields --
+
+  /// Child widget supplied by the default and [BentoCard.shaped] constructors.
+  /// `null` for named-constructor modes that build their own content.
+  final Widget? child;
+
+  /// Number of grid columns this card spans.
+  final int columnSpan;
+
+  /// Number of grid rows this card spans.
+  final int rowSpan;
+
+  /// Background color. Defaults to [ColorScheme.surfaceContainer].
+  final Color? backgroundColor;
+
+  /// Delay before the entrance animation starts.
+  final int delayInMilliseconds;
+
+  /// Whether to use a pill (stadium) shape instead of the bento border shape.
+  final bool pillShape;
+
+  // -- Private fields set by [BentoCard.shaped] (and [BentoCard.hero]) --
+
+  /// Optional Material 3 Expressive shape.
+  ///
+  /// When set, overrides [pillShape] and the default bento border shape.
+  /// Only available via [BentoCard.shaped] and [BentoCard.hero].
+  final Shapes? _m3eShape;
+
+  /// Duration for one full rotation of the M3E shape background.
+  ///
+  /// [Duration.zero] (default) disables rotation.
+  /// Only takes effect when [_m3eShape] is set.
+  /// Only available via [BentoCard.shaped] and [BentoCard.hero].
+  final Duration _rotateDuration;
+
+  // -- Private fields set by named constructors --
+
+  final _BentoCardMode _mode;
+  final String? _label;
+  final String? _value;
+  final int _valueFlex;
+  final bool _reversed;
+
+  // -- Build helpers --
+
+  Widget _buildText(BuildContext context) {
+    return Padding(
+      padding: EdgeInsets.symmetric(
+        horizontal: TraleTheme.of(context)!.padding / 2,
+      ),
+      child: Column(
+        mainAxisAlignment: MainAxisAlignment.center,
+        children: <Widget>[
+          AutoSizeText(
+            _label!,
+            style: Theme.of(context).textTheme.bodySmall!.copyWith(
+              color: Theme.of(context).colorScheme.onSurface,
+            ),
+            maxLines: 2,
+            textAlign: TextAlign.center,
+          ),
+          AutoSizeText(
+            _value!,
+            style: Theme.of(context).textTheme.emphasized.bodyLarge!.copyWith(
+              color: Theme.of(context).colorScheme.onSurface,
+              fontWeight: FontWeight.w700,
+            ),
+            maxLines: 1,
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildTextEmphasized(BuildContext context) {
+    final Widget labelWidget = Expanded(
+      child: Align(
+        alignment: Alignment.center,
+        child: AutoSizeText(
+          _label!,
+          style: Theme.of(context).textTheme.bodyLarge!.onSurface(context),
+          maxLines: 2,
+          textAlign: TextAlign.center,
+        ),
+      ),
+    );
+    final Widget valueWidget = Expanded(
+      flex: _valueFlex,
+      child: Align(
+        alignment: Alignment.center,
+        child: AutoSizeText(
+          _value!,
+          style: Theme.of(context).textTheme.emphasized.bodyMedium!
+              .onSurface(context)
+              .copyWith(
+                fontWeight: FontWeight.w700,
+                fontSize: 200,
+                height: 0.7,
+              ),
+          maxLines: 1,
+        ),
+      ),
+    );
+    return Padding(
+      padding: EdgeInsets.all(TraleTheme.of(context)!.padding / 2),
+      child: Column(
+        mainAxisAlignment: MainAxisAlignment.center,
+        children: _reversed
+            ? <Widget>[valueWidget, labelWidget]
+            : <Widget>[labelWidget, valueWidget],
+      ),
+    );
+  }
+
+  Widget _buildTextInline(BuildContext context) {
+    final Widget labelWidget = Expanded(
+      child: Align(
+        alignment: Alignment.center,
+        child: AutoSizeText(
+          _label!,
+          style: Theme.of(context).textTheme.bodyMedium!.copyWith(height: 1.0),
+          maxLines: 2,
+          textAlign: TextAlign.center,
+        ),
+      ),
+    );
+    final Widget valueWidget = Expanded(
+      flex: _valueFlex,
+      child: Align(
+        alignment: Alignment.center,
+        child: AutoSizeText(
+          _value!,
+          style: Theme.of(context).textTheme.emphasized.displayLarge!.copyWith(
+            fontWeight: FontWeight.w900,
+            fontSize: 200,
+          ),
+          maxLines: 1,
+        ),
+      ),
+    );
+    return Row(
+      mainAxisAlignment: MainAxisAlignment.center,
+      children: _reversed
+          ? <Widget>[valueWidget, labelWidget]
+          : <Widget>[labelWidget, valueWidget],
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final TraleTheme theme = TraleTheme.of(context)!;
+    final Color bgColor =
+        backgroundColor ?? Theme.of(context).colorScheme.surfaceContainer;
+
+    final ShapeBorder shape = _m3eShape != null
+        ? M3EShapeBorder(shape: _m3eShape)
+        : pillShape
+        ? const StadiumBorder()
+        : theme.bentoBorderShape;
+
+    final Widget content = switch (_mode) {
+      _BentoCardMode.custom => child!,
+      _BentoCardMode.text => _buildText(context),
+      _BentoCardMode.textEmphasized => _buildTextEmphasized(context),
+      _BentoCardMode.textInline => _buildTextInline(context),
+    };
+
+    // Rotating M3E shape: shape background spins, content stays.
+    // Circular clip with padding, rotating shape behind content.
+    // Content is constrained to the inscribed square of the circle
+    // (side = diameter / √2) so text never reaches the oval edge.
+    if (_rotateDuration > Duration.zero && _m3eShape != null) {
+      return AnimateInEffect(
+        delayInMilliseconds: delayInMilliseconds,
+        durationInMilliseconds: theme.transitionDuration.slow.inMilliseconds,
+        child: LayoutBuilder(
+          builder: (BuildContext context, BoxConstraints constraints) {
+            final double side = constraints.biggest.shortestSide;
+            final double padding = theme.padding / 2;
+            final double diameter = side - padding * 2;
+            final double innerSide = diameter / math.sqrt2;
+            return Center(
+              child: SizedBox(
+                width: diameter,
+                height: diameter,
+                child: ClipOval(
+                  child: Stack(
+                    alignment: Alignment.center,
+                    children: <Widget>[
+                      _RotatingShape(
+                        shape: _m3eShape,
+                        color: bgColor,
+                        duration: _rotateDuration,
+                      ),
+                      SizedBox(
+                        width: innerSide,
+                        height: innerSide,
+                        child: content,
+                      ),
+                    ],
+                  ),
+                ),
+              ),
+            );
+          },
+        ),
+      );
+    }
+
+    return AnimateInEffect(
+      delayInMilliseconds: delayInMilliseconds,
+      durationInMilliseconds: theme.transitionDuration.slow.inMilliseconds,
+      child: Card(
+        shape: shape,
+        color: bgColor,
+        margin: EdgeInsets.zero,
+        clipBehavior: Clip.hardEdge,
+        child: content,
+      ),
+    );
+  }
+}
+
+/// Hero content widget: large display number with a subtitle below.
+///
+/// Used internally by [BentoCard.hero].
+class _HeroContent extends StatelessWidget {
+  const _HeroContent({
+    required this.label,
+    required this.value,
+    this.textColor,
+    this.valueFlex = 2,
+    this.labelFlex = 1,
+  });
+
+  final String label;
+  final String value;
+  final Color? textColor;
+  final int valueFlex;
+  final int labelFlex;
+
+  @override
+  Widget build(BuildContext context) {
+    final Color color = textColor ?? Theme.of(context).colorScheme.onSurface;
+    return Padding(
+      padding: EdgeInsets.all(TraleTheme.of(context)!.padding / 2),
+      child: Column(
+        mainAxisAlignment: MainAxisAlignment.center,
+        children: <Widget>[
+          Expanded(
+            flex: valueFlex,
+            child: Align(
+              alignment: Alignment.center,
+              child: AutoSizeText(
+                value,
+                style: Theme.of(context).textTheme.emphasized.displayLarge!
+                    .copyWith(
+                      color: color,
+                      fontWeight: FontWeight.w700,
+                      fontSize: 200,
+                    ),
+                maxLines: 1,
+              ),
+            ),
+          ),
+          Expanded(
+            flex: labelFlex,
+            child: Align(
+              alignment: Alignment.topCenter,
+              child: AutoSizeText(
+                label,
+                style: Theme.of(
+                  context,
+                ).textTheme.bodyLarge!.copyWith(color: color, height: 1.0),
+                maxLines: 3,
+                textAlign: TextAlign.center,
+              ),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+/// A continuously rotating M3E shape background.
+class _RotatingShape extends StatefulWidget {
+  const _RotatingShape({
+    required this.shape,
+    required this.color,
+    required this.duration,
+  });
+
+  final Shapes shape;
+  final Color color;
+  final Duration duration;
+
+  @override
+  State<_RotatingShape> createState() => _RotatingShapeState();
+}
+
+class _RotatingShapeState extends State<_RotatingShape>
+    with SingleTickerProviderStateMixin {
+  late final AnimationController _controller;
+
+  @override
+  void initState() {
+    super.initState();
+    _controller = AnimationController(vsync: this, duration: widget.duration)
+      ..repeat();
+  }
+
+  @override
+  void dispose() {
+    _controller.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return RotationTransition(
+      turns: _controller,
+      child: SizedBox.expand(
+        child: DecoratedBox(
+          decoration: ShapeDecoration(
+            shape: M3EShapeBorder(shape: widget.shape),
+            color: widget.color,
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/app/lib/widget/bento_card.dart
+++ b/app/lib/widget/bento_card.dart
@@ -366,22 +366,22 @@ class BentoCard extends StatelessWidget {
               child: SizedBox(
                 width: diameter,
                 height: diameter,
-                child: ClipOval(
-                  child: Stack(
-                    alignment: Alignment.center,
-                    children: <Widget>[
-                      _RotatingShape(
-                        shape: _m3eShape,
-                        color: bgColor,
-                        duration: _rotateDuration,
-                      ),
-                      SizedBox(
+                child: Stack(
+                  alignment: Alignment.center,
+                  children: <Widget>[
+                    _RotatingShape(
+                      shape: _m3eShape,
+                      color: bgColor,
+                      duration: _rotateDuration,
+                    ),
+                    ClipOval(
+                      child: SizedBox(
                         width: innerSide,
                         height: innerSide,
                         child: content,
                       ),
-                    ],
-                  ),
+                    ),
+                  ],
                 ),
               ),
             );

--- a/app/lib/widget/bento_grid.dart
+++ b/app/lib/widget/bento_grid.dart
@@ -1,0 +1,158 @@
+import 'package:flutter/material.dart';
+import 'package:trale/core/theme.dart';
+import 'package:trale/widget/bento_card.dart';
+
+/// Computed position and size for a single [BentoCard] within the grid.
+class _BentoPlacement {
+  _BentoPlacement({
+    required this.card,
+    required this.column,
+    required this.row,
+  });
+
+  final BentoCard card;
+  final int column;
+  final int row;
+}
+
+/// A bento-style grid layout that auto-arranges [BentoCard] children.
+///
+/// Each child specifies its own [BentoCard.columnSpan] and
+/// [BentoCard.rowSpan]. The grid packs them using a 2D first-fit algorithm
+/// so that cards fill the available space without gaps.
+///
+/// Grid cells are always square (1:1 aspect ratio).
+/// Outer horizontal padding uses [TraleTheme.padding].
+/// Gaps between cards use [TraleTheme.bentoPadding].
+/// Card shapes default to [TraleTheme.bentoBorderShape].
+class BentoGrid extends StatelessWidget {
+  /// Constructor.
+  const BentoGrid({required this.children, this.columns = 12, super.key});
+
+  /// Cards to lay out.
+  final List<BentoCard> children;
+
+  /// Total number of columns in the grid.
+  final int columns;
+
+  /// Pack cards using a 2D first-fit algorithm.
+  ///
+  /// Maintains a grid of occupied cells and, for every card, scans
+  /// top-to-bottom then left-to-right to find the first position
+  /// where the card's full rectangle is unoccupied. This fills gaps
+  /// that a 1D skyline approach would skip.
+  List<_BentoPlacement> _computePlacements(double gap) {
+    // Dynamic height – grows as needed.
+    final int initialRows = children.length * 2;
+    final List<List<bool>> grid = List<List<bool>>.generate(
+      initialRows,
+      (_) => List<bool>.filled(columns, false),
+    );
+
+    final List<_BentoPlacement> placements = <_BentoPlacement>[];
+
+    for (final BentoCard card in children) {
+      final int colSpan = card.columnSpan.clamp(1, columns);
+      final int rowSpan = card.rowSpan.clamp(1, 100);
+
+      bool placed = false;
+      for (int row = 0; !placed; row++) {
+        // Grow the grid if necessary.
+        while (row + rowSpan > grid.length) {
+          grid.add(List<bool>.filled(columns, false));
+        }
+        for (int col = 0; col <= columns - colSpan; col++) {
+          if (_fits(grid, row, col, rowSpan, colSpan)) {
+            placements.add(_BentoPlacement(card: card, column: col, row: row));
+            _occupy(grid, row, col, rowSpan, colSpan);
+            placed = true;
+            break;
+          }
+        }
+      }
+    }
+
+    return placements;
+  }
+
+  /// Returns `true` when every cell in the rectangle is free.
+  static bool _fits(
+    List<List<bool>> grid,
+    int row,
+    int col,
+    int rowSpan,
+    int colSpan,
+  ) {
+    for (int r = row; r < row + rowSpan; r++) {
+      for (int c = col; c < col + colSpan; c++) {
+        if (grid[r][c]) {
+          return false;
+        }
+      }
+    }
+    return true;
+  }
+
+  /// Marks every cell in the rectangle as occupied.
+  static void _occupy(
+    List<List<bool>> grid,
+    int row,
+    int col,
+    int rowSpan,
+    int colSpan,
+  ) {
+    for (int r = row; r < row + rowSpan; r++) {
+      for (int c = col; c < col + colSpan; c++) {
+        grid[r][c] = true;
+      }
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final TraleTheme theme = TraleTheme.of(context)!;
+    final double gap = theme.bentoPadding;
+    final double availableWidth =
+        MediaQuery.sizeOf(context).width - 2 * theme.padding;
+    final double cellSize = (availableWidth - (columns - 1) * gap) / columns;
+
+    final List<_BentoPlacement> placements = _computePlacements(gap);
+
+    // Determine total height from the deepest card.
+    int maxRow = 0;
+    for (final _BentoPlacement p in placements) {
+      final int endRow = p.row + p.card.rowSpan.clamp(1, 100);
+      if (endRow > maxRow) {
+        maxRow = endRow;
+      }
+    }
+
+    final double totalHeight = maxRow > 0
+        ? maxRow * cellSize + (maxRow - 1) * gap
+        : 0;
+
+    return Padding(
+      padding: EdgeInsets.symmetric(horizontal: theme.padding),
+      child: SizedBox(
+        height: totalHeight,
+        child: Stack(
+          children: <Widget>[
+            for (final _BentoPlacement p in placements)
+              Positioned(
+                left: p.column * (cellSize + gap),
+                top: p.row * (cellSize + gap),
+                width:
+                    p.card.columnSpan * cellSize +
+                    (p.card.columnSpan - 1) * gap,
+                height: () {
+                  final int rs = p.card.rowSpan.clamp(1, 100);
+                  return rs * cellSize + (rs - 1) * gap;
+                }(),
+                child: p.card,
+              ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/app/lib/widget/ioWidgets.dart
+++ b/app/lib/widget/ioWidgets.dart
@@ -146,7 +146,7 @@ List<int>? openScaleIndices(List<String?> lines, {String separator = ','}) {
 
 /// Import backup
 Future<bool> importBackup(BuildContext context) async {
-  final FilePickerResult? pickerResult = await FilePicker.platform.pickFiles(
+  final FilePickerResult? pickerResult = await FilePicker.pickFiles(
     type: FileType.custom,
     allowedExtensions: <String>['txt', 'csv'],
   );

--- a/app/lib/widget/linechart.dart
+++ b/app/lib/widget/linechart.dart
@@ -125,6 +125,7 @@ class CustomLineChart extends StatefulWidget {
 class _CustomLineChartState extends State<CustomLineChart> {
   late double minX;
   late double maxX;
+  bool _isDragging = false;
   @override
   void initState() {
     super.initState();
@@ -221,6 +222,7 @@ class _CustomLineChartState extends State<CustomLineChart> {
     final Color targetWeightLabelBackgroundColor =
         widget.targetWeightLabelBackgroundColor ??
         colorScheme.surfaceContainerLow;
+    final Color tooltipLineColor = colorScheme.tertiary;
 
     final List<FlSpot> measurements = vectorsToFlSpot(msTimes, ms);
     final List<FlSpot> measurementsInterpol = vectorsToFlSpot(
@@ -323,13 +325,135 @@ class _CustomLineChartState extends State<CustomLineChart> {
     }
 
     Widget lineChart(double minX, double maxX, double minY, double maxY) {
+      // Find the interpolation spot whose x is closest to the visible centre.
+      int centerInterpolIdx = 0;
+      if (measurementsInterpol.isNotEmpty) {
+        final double centerX = (minX + maxX) / 2;
+        double minDist = double.infinity;
+        for (int i = 0; i < measurementsInterpol.length; i++) {
+          final double dist = (measurementsInterpol[i].x - centerX).abs();
+          if (dist < minDist) {
+            minDist = dist;
+            centerInterpolIdx = i;
+          }
+        }
+      }
+
+      // Dot radius – same formula used for measurement dots.
+      final double dotRadius =
+          max<double>(5 - (maxX - minX) / (90 * 24 * 3600 * 1000), 1.0) + 0.4;
+
+      // Build the interpolation bar once so we can reference it in both
+      // lineBarsData and showingTooltipIndicators.
+      final LineChartBarData interpolBarData = LineChartBarData(
+        spots: measurementsInterpol,
+        showingIndicators:
+            (!widget.isPreview &&
+                _isDragging &&
+                measurementsInterpol.isNotEmpty)
+            ? <int>[centerInterpolIdx]
+            : <int>[],
+        isCurved: true,
+        color: interpolationLineColor,
+        barWidth: 3,
+        isStrokeCapRound: true,
+        dotData: const FlDotData(show: false),
+        belowBarData: BarAreaData(
+          show: true,
+          color: interpolationBelowAreaColor,
+        ),
+        aboveBarData: BarAreaData(
+          show: targetWeight != null,
+          color: interpolationAboveAreaColor,
+          cutOffY: targetWeight ?? 0,
+          applyCutOffY: true,
+        ),
+      );
+
       return LineChart(
         LineChartData(
           minX: minX,
           maxX: maxX,
           minY: minY.floorToDouble(),
           maxY: maxY.ceilToDouble(),
-          lineTouchData: const LineTouchData(enabled: false),
+          showingTooltipIndicators:
+              (!widget.isPreview &&
+                  _isDragging &&
+                  measurementsInterpol.isNotEmpty)
+              ? <ShowingTooltipIndicators>[
+                  ShowingTooltipIndicators(<LineBarSpot>[
+                    LineBarSpot(
+                      interpolBarData,
+                      0,
+                      measurementsInterpol[centerInterpolIdx],
+                    ),
+                  ]),
+                ]
+              : <ShowingTooltipIndicators>[],
+          lineTouchData: widget.isPreview
+              ? const LineTouchData(enabled: false)
+              : LineTouchData(
+                  enabled: false,
+                  handleBuiltInTouches: false,
+                  getTouchedSpotIndicator:
+                      (LineChartBarData barData, List<int> spotIndexes) =>
+                          spotIndexes
+                              .map(
+                                (int index) => TouchedSpotIndicatorData(
+                                  FlLine(
+                                    color: tooltipLineColor,
+                                    strokeWidth: 2,
+                                  ),
+                                  FlDotData(
+                                    getDotPainter:
+                                        (
+                                          FlSpot spot,
+                                          double percent,
+                                          LineChartBarData barData,
+                                          int index,
+                                        ) => FlDotCirclePainter(
+                                          radius: dotRadius,
+                                          color: tooltipLineColor,
+                                          strokeColor: tooltipLineColor,
+                                          strokeWidth: 0.2,
+                                        ),
+                                  ),
+                                ),
+                              )
+                              .toList(),
+                  touchTooltipData: LineTouchTooltipData(
+                    getTooltipColor: (_) => colorScheme.surfaceContainerHigh,
+                    fitInsideHorizontally: true,
+                    tooltipPadding: const EdgeInsets.symmetric(
+                      horizontal: 8,
+                      vertical: 4,
+                    ),
+                    getTooltipItems: (List<LineBarSpot> touchedSpots) =>
+                        touchedSpots.map((LineBarSpot spot) {
+                          final DateTime date =
+                              DateTime.fromMillisecondsSinceEpoch(
+                                spot.x.toInt(),
+                              );
+                          return LineTooltipItem(
+                            notifier.dayFormat(context).format(date),
+                            theme.textTheme.bodySmall!.copyWith(
+                              color: colorScheme.onSurface,
+                            ),
+                            textAlign: TextAlign.center,
+                            children: <TextSpan>[
+                              TextSpan(
+                                text:
+                                    '\n${notifier.unit.weightToString(spot.y * unitScaling, notifier.unitPrecision)}',
+                                style: theme.textTheme.bodySmall!.copyWith(
+                                  color: colorScheme.onSurface,
+                                  fontWeight: FontWeight.bold,
+                                ),
+                              ),
+                            ],
+                          );
+                        }).toList(),
+                  ),
+                ),
           borderData: FlBorderData(show: false),
           gridData: const FlGridData(show: false),
           titlesData: FlTitlesData(
@@ -385,24 +509,7 @@ class _CustomLineChartState extends State<CustomLineChart> {
             ],
           ),
           lineBarsData: <LineChartBarData>[
-            LineChartBarData(
-              spots: measurementsInterpol,
-              isCurved: true,
-              color: interpolationLineColor,
-              barWidth: 3,
-              isStrokeCapRound: true,
-              dotData: const FlDotData(show: false),
-              belowBarData: BarAreaData(
-                show: true,
-                color: interpolationBelowAreaColor,
-              ),
-              aboveBarData: BarAreaData(
-                show: targetWeight != null,
-                color: interpolationAboveAreaColor,
-                cutOffY: targetWeight ?? 0,
-                applyCutOffY: true,
-              ),
-            ),
+            interpolBarData,
             LineChartBarData(
               spots: measurements,
               isCurved: false,
@@ -490,19 +597,25 @@ class _CustomLineChartState extends State<CustomLineChart> {
     void dragUpdate(DragUpdateDetails dragUpdDet) {
       if (!widget.isPreview) {
         setState(() {
+          _isDragging = true;
           final double primDelta =
               (dragUpdDet.primaryDelta ?? 0.0) * (maxX - minX) / 100;
 
-          final double allowedMaxX =
+          final double range = maxX - minX;
+          final double dataMaxX =
               interpolTimes.last > DateTime.now().millisecondsSinceEpoch
               ? interpolTimes.last
               : DateTime.now().millisecondsSinceEpoch.toDouble();
-          final double allowedMinX = interpolTimes.first;
-          if (maxX - primDelta <= allowedMaxX &&
-              minX - primDelta >= allowedMinX) {
-            maxX -= primDelta;
-            minX -= primDelta;
-          }
+          // Allow scrolling until the first/last interpolation point is
+          // centred in the visible window.
+          final double allowedMaxX = dataMaxX + range / 2;
+          final double allowedMinX = interpolTimes.first - range / 2;
+          final double newMaxX = (maxX - primDelta).clamp(
+            allowedMinX + range,
+            allowedMaxX,
+          );
+          maxX = newMaxX;
+          minX = newMaxX - range;
         });
       }
     }
@@ -535,6 +648,8 @@ class _CustomLineChartState extends State<CustomLineChart> {
               onDoubleTap: doubleTap,
               //onScaleUpdate: scaleUpdate,
               onHorizontalDragUpdate: dragUpdate,
+              onHorizontalDragEnd: (_) => setState(() => _isDragging = false),
+              onHorizontalDragCancel: () => setState(() => _isDragging = false),
               child: lineChart(minX, maxX, minY, maxY),
             ),
           ),
@@ -569,7 +684,7 @@ class _CustomLineChartState extends State<CustomLineChart> {
                     ),
                     GroupedWidget(
                       child: IconButton(
-                        onPressed: notifier.zoomLevel == ZoomLevel.two
+                        onPressed: notifier.zoomLevel == ZoomLevel.one
                             ? null
                             : () {
                                 notifier.zoomIn();

--- a/app/lib/widget/linechart.dart
+++ b/app/lib/widget/linechart.dart
@@ -129,12 +129,8 @@ class _CustomLineChartState extends State<CustomLineChart> {
   void initState() {
     super.initState();
     final Preferences prefs = Preferences();
-    minX = widget.isPreview
-        ? widget.ip.timesDisplay.first
-        : prefs.zoomLevel.minX;
-    maxX = widget.isPreview
-        ? widget.ip.timesDisplay.last
-        : prefs.zoomLevel.maxX;
+    minX = widget.isPreview ? widget.ip.times.first : prefs.zoomLevel.minX;
+    maxX = widget.isPreview ? widget.ip.times.last : prefs.zoomLevel.maxX;
   }
 
   @override
@@ -142,12 +138,8 @@ class _CustomLineChartState extends State<CustomLineChart> {
     super.didUpdateWidget(oldWidget);
     if (oldWidget.isPreview != widget.isPreview || oldWidget.ip != widget.ip) {
       final Preferences prefs = Preferences();
-      minX = widget.isPreview
-          ? widget.ip.timesDisplay.first
-          : prefs.zoomLevel.minX;
-      maxX = widget.isPreview
-          ? widget.ip.timesDisplay.last
-          : prefs.zoomLevel.maxX;
+      minX = widget.isPreview ? widget.ip.times.first : prefs.zoomLevel.minX;
+      maxX = widget.isPreview ? widget.ip.times.last : prefs.zoomLevel.maxX;
     }
   }
 
@@ -158,8 +150,9 @@ class _CustomLineChartState extends State<CustomLineChart> {
     final MeasurementInterpolationBaseclass ip = widget.ip;
 
     // load times
-    final ml.Vector msTimes = ip.timesMeasured;
-    final ml.Vector interpolTimes = ip.timesDisplay;
+    final ({ml.Vector times, ml.Vector measurements}) msData = ip.measured();
+    final ml.Vector msTimes = msData.times;
+    final ml.Vector interpolTimes = ip.times;
 
     // scale to unit
     final double unitScaling = Provider.of<TraleNotifier>(
@@ -168,14 +161,14 @@ class _CustomLineChartState extends State<CustomLineChart> {
     ).unit.scaling;
 
     final ml.Vector ms = widget.loadedFirst
-        ? ml.Vector.filled(ip.weightsMeasured.length, ip.weightsMeasured.mean())
-        : ip.weightsMeasured;
-    final ml.Vector interpol = widget.loadedFirst
         ? ml.Vector.filled(
-            ip.weightsDisplay.length,
-            ip.weightsDisplay.sum() / ip.isNotExtrapolated.sum(),
+            msData.measurements.length,
+            msData.measurements.mean(),
           )
-        : ip.weightsDisplay;
+        : msData.measurements;
+    final ml.Vector interpol = widget.loadedFirst
+        ? ml.Vector.filled(ip.weights.length, ip.weights.mean())
+        : ip.weights;
 
     final TextStyle labelTextStyle = theme.textTheme.monospace.bodySmall!.apply(
       color: widget.axisLabelColor ?? colorScheme.onSurface,

--- a/app/lib/widget/linechart.dart
+++ b/app/lib/widget/linechart.dart
@@ -394,8 +394,12 @@ class _CustomLineChartState extends State<CustomLineChart>
           showTitles: true,
           reservedSize: textSize.height * 2,
           interval: 24 * 3600 * 1000, // days
-          getTitlesWidget: (double time, TitleMeta titleMeta) =>
-              time2xtickwidget(time),
+          getTitlesWidget: (double time, TitleMeta titleMeta) {
+            if (time == titleMeta.min || time == titleMeta.max) {
+              return const SizedBox.shrink();
+            }
+            return time2xtickwidget(time);
+          },
         ),
       );
     }

--- a/app/lib/widget/linechart.dart
+++ b/app/lib/widget/linechart.dart
@@ -706,7 +706,35 @@ class _CustomLineChartState extends State<CustomLineChart>
           allowedMinX + range,
           allowedMaxX,
         );
-        _animateTo(newMaxX - range, newMaxX);
+        _snapTo(newMaxX - range, newMaxX);
+        setState(() {});
+      }
+    }
+
+    void dragEnd(DragEndDetails details) {
+      if (!widget.isPreview) {
+        final double velocity = details.primaryVelocity ?? 0.0;
+        if (velocity.abs() > 50) {
+          final double range = maxX - minX;
+          final double dataMaxX =
+              interpolTimes.last > DateTime.now().millisecondsSinceEpoch
+              ? interpolTimes.last
+              : DateTime.now().millisecondsSinceEpoch.toDouble();
+          final double allowedMaxX = dataMaxX + range / 2;
+          final double allowedMinX = interpolTimes.first - range / 2;
+          // Convert pixel velocity to chart-coordinate fling distance.
+          // Uses the same scale factor as dragUpdate (range / 100 per pixel).
+          final double flingDelta = -velocity * (range / 100) * 0.3;
+          final double newMaxX = (maxX + flingDelta).clamp(
+            allowedMinX + range,
+            allowedMaxX,
+          );
+          _animateTo(newMaxX - range, newMaxX);
+        }
+        _tooltipTimer?.cancel();
+        _tooltipTimer = Timer(const Duration(seconds: 3), () {
+          if (mounted) setState(() => _showTooltip = false);
+        });
       }
     }
 
@@ -735,12 +763,7 @@ class _CustomLineChartState extends State<CustomLineChart>
               onDoubleTap: doubleTap,
               //onScaleUpdate: scaleUpdate,
               onHorizontalDragUpdate: dragUpdate,
-              onHorizontalDragEnd: (_) {
-                _tooltipTimer?.cancel();
-                _tooltipTimer = Timer(const Duration(seconds: 3), () {
-                  if (mounted) setState(() => _showTooltip = false);
-                });
-              },
+              onHorizontalDragEnd: dragEnd,
               onHorizontalDragCancel: () {
                 _tooltipTimer?.cancel();
                 _tooltipTimer = Timer(const Duration(seconds: 3), () {

--- a/app/lib/widget/linechart.dart
+++ b/app/lib/widget/linechart.dart
@@ -1,3 +1,4 @@
+import 'dart:async';
 import 'dart:math';
 
 import 'package:fl_chart/fl_chart.dart';
@@ -122,16 +123,81 @@ class CustomLineChart extends StatefulWidget {
   State<CustomLineChart> createState() => _CustomLineChartState();
 }
 
-class _CustomLineChartState extends State<CustomLineChart> {
+class _CustomLineChartState extends State<CustomLineChart>
+    with SingleTickerProviderStateMixin {
+  // Animation targets (where the viewport will end up).
   late double minX;
   late double maxX;
-  bool _isDragging = false;
+
+  // Current animated viewport values – driven by [_viewAnim].
+  // Both the LineChart viewport and the tooltip centre are derived from these,
+  // so they are always in perfect sync with zero double-animation.
+  late double _curMinX;
+  late double _curMaxX;
+  double _fromMinX = 0;
+  double _fromMaxX = 0;
+
+  bool _showTooltip = false;
+  Timer? _tooltipTimer;
+
+  late AnimationController _viewAnim;
+
+  void _onViewAnimTick() {
+    final double t = Curves.easeOut.transform(_viewAnim.value);
+    setState(() {
+      _curMinX = _fromMinX + (minX - _fromMinX) * t;
+      _curMaxX = _fromMaxX + (maxX - _fromMaxX) * t;
+    });
+  }
+
+  /// Animate the viewport from the current visual position to [newMinX]/[newMaxX].
+  void _animateTo(double newMinX, double newMaxX) {
+    _viewAnim.stop();
+    _fromMinX = _curMinX;
+    _fromMaxX = _curMaxX;
+    minX = newMinX;
+    maxX = newMaxX;
+    _viewAnim.forward(from: 0.0);
+  }
+
+  /// Snap the viewport instantly to [newMinX]/[newMaxX] (no animation).
+  void _snapTo(double newMinX, double newMaxX) {
+    _viewAnim.stop();
+    minX = newMinX;
+    maxX = newMaxX;
+    _curMinX = newMinX;
+    _curMaxX = newMaxX;
+    _fromMinX = newMinX;
+    _fromMaxX = newMaxX;
+  }
+
+  @override
+  void dispose() {
+    _tooltipTimer?.cancel();
+    _viewAnim.dispose();
+    super.dispose();
+  }
+
   @override
   void initState() {
     super.initState();
     final Preferences prefs = Preferences();
-    minX = widget.isPreview ? widget.ip.times.first : prefs.zoomLevel.minX;
-    maxX = widget.isPreview ? widget.ip.times.last : prefs.zoomLevel.maxX;
+    final double initMinX = widget.isPreview
+        ? widget.ip.times.first
+        : prefs.zoomLevel.minX;
+    final double initMaxX = widget.isPreview
+        ? widget.ip.times.last
+        : prefs.zoomLevel.maxX;
+    minX = initMinX;
+    maxX = initMaxX;
+    _curMinX = initMinX;
+    _curMaxX = initMaxX;
+    _fromMinX = initMinX;
+    _fromMaxX = initMaxX;
+    _viewAnim = AnimationController(
+      vsync: this,
+      duration: const Duration(milliseconds: 500),
+    )..addListener(_onViewAnimTick);
   }
 
   @override
@@ -139,8 +205,13 @@ class _CustomLineChartState extends State<CustomLineChart> {
     super.didUpdateWidget(oldWidget);
     if (oldWidget.isPreview != widget.isPreview || oldWidget.ip != widget.ip) {
       final Preferences prefs = Preferences();
-      minX = widget.isPreview ? widget.ip.times.first : prefs.zoomLevel.minX;
-      maxX = widget.isPreview ? widget.ip.times.last : prefs.zoomLevel.maxX;
+      final double newMinX = widget.isPreview
+          ? widget.ip.times.first
+          : prefs.zoomLevel.minX;
+      final double newMaxX = widget.isPreview
+          ? widget.ip.times.last
+          : prefs.zoomLevel.maxX;
+      _snapTo(newMinX, newMaxX);
     }
   }
 
@@ -231,9 +302,10 @@ class _CustomLineChartState extends State<CustomLineChart> {
     );
 
     final int indexFirst = measurements.lastIndexWhere(
-      (FlSpot e) => e.x < minX,
+      (FlSpot e) => e.x < _curMinX,
     );
-    final int indexLast = measurements.indexWhere((FlSpot e) => e.x > maxX) + 1;
+    final int indexLast =
+        measurements.indexWhere((FlSpot e) => e.x > _curMaxX) + 1;
     final List<FlSpot> shownData = measurements.sublist(
       indexFirst == -1 ? 0 : indexFirst,
       (indexLast == -1 ||
@@ -264,50 +336,66 @@ class _CustomLineChartState extends State<CustomLineChart> {
       maxY = (maxY + minY) / 2 + 1;
     }
 
-    /// convert time [ms since Epoch] to xtick label
-    String time2xticklabel(double time) {
+    /// Build the x-tick label widget for a given [time] (ms since epoch).
+    /// For January 1st, shows the month name and the year in bold below it.
+    Widget time2xtickwidget(double time) {
       final DateTime date = DateTime.fromMillisecondsSinceEpoch(time.toInt());
+      final String locale = Localizations.localeOf(context).languageCode;
       final int interval =
-          (max<double>(maxX - minX, 1) / (24 * 3600 * 1000) ~/ 6).toInt();
+          (max<double>(_curMaxX - _curMinX, 1) / (24 * 3600 * 1000) ~/ 6)
+              .toInt();
       if (date.day == 1 && date.month == 1) {
-        return DateFormat(
-          'yy',
-          Localizations.localeOf(context).languageCode,
-        ).format(date);
+        // January 1st: year on top row, month on bottom row
+        return Column(
+          mainAxisAlignment: MainAxisAlignment.spaceBetween,
+          children: <Widget>[
+            AutoSizeText(
+              DateFormat('yyyy', locale).format(date),
+              style: labelTextStyle.copyWith(fontWeight: FontWeight.bold),
+            ),
+            AutoSizeText(
+              DateFormat('MMM', locale).format(date),
+              style: labelTextStyle,
+            ),
+          ],
+        );
       } else if (date.day == 1) {
-        // if tick interval of more than 45 days show only every second tick
-        // starting from the first date of shown range.
+        // First of month – align to bottom to match the 'Jan' row position
         if ((interval <= 45) ||
             (interval > 45 && interval < 75 && date.month % 2 == 1) ||
             (interval >= 75 && interval < 120 && date.month % 3 == 1) ||
             (interval >= 120 && date.month % 6 == 1)) {
-          return DateFormat(
-            'MMM',
-            Localizations.localeOf(context).languageCode,
-          ).format(date);
+          return Align(
+            alignment: Alignment.bottomCenter,
+            child: AutoSizeText(
+              DateFormat('MMM', locale).format(date),
+              style: labelTextStyle,
+            ),
+          );
         }
-        return '';
+        return const SizedBox.shrink();
       } else if (date.month !=
               date.add(Duration(days: interval ~/ 1.5)).month ||
-          (maxX - date.millisecondsSinceEpoch <
+          (_curMaxX - date.millisecondsSinceEpoch <
               const Duration(days: 1).inMilliseconds)) {
-        return '';
+        return const SizedBox.shrink();
       } else if (date.day % interval == 0 && date.day - interval ~/ 1.5 > 0) {
-        return date.day.toString();
+        return Align(
+          alignment: Alignment.bottomCenter,
+          child: AutoSizeText(date.day.toString(), style: labelTextStyle),
+        );
       }
-      return '';
+      return const SizedBox.shrink();
     }
 
     AxisTitles bottomTitles() {
       return AxisTitles(
         sideTitles: SideTitles(
           showTitles: true,
-          reservedSize: textSize.height + margin,
+          reservedSize: textSize.height * 2,
           interval: 24 * 3600 * 1000, // days
-          getTitlesWidget: (double time, TitleMeta titleMeta) => Padding(
-            padding: EdgeInsets.only(top: margin),
-            child: AutoSizeText(time2xticklabel(time), style: labelTextStyle),
-          ),
+          getTitlesWidget: (double time, TitleMeta titleMeta) =>
+              time2xtickwidget(time),
         ),
       );
     }
@@ -325,7 +413,8 @@ class _CustomLineChartState extends State<CustomLineChart> {
     }
 
     Widget lineChart(double minX, double maxX, double minY, double maxY) {
-      // Find the interpolation spot whose x is closest to the visible centre.
+      // centerX is derived directly from the animated viewport values, so
+      // the tooltip spot is always in sync with the visible chart centre.
       int centerInterpolIdx = 0;
       if (measurementsInterpol.isNotEmpty) {
         final double centerX = (minX + maxX) / 2;
@@ -349,7 +438,7 @@ class _CustomLineChartState extends State<CustomLineChart> {
         spots: measurementsInterpol,
         showingIndicators:
             (!widget.isPreview &&
-                _isDragging &&
+                _showTooltip &&
                 measurementsInterpol.isNotEmpty)
             ? <int>[centerInterpolIdx]
             : <int>[],
@@ -378,7 +467,7 @@ class _CustomLineChartState extends State<CustomLineChart> {
           maxY: maxY.ceilToDouble(),
           showingTooltipIndicators:
               (!widget.isPreview &&
-                  _isDragging &&
+                  _showTooltip &&
                   measurementsInterpol.isNotEmpty)
               ? <ShowingTooltipIndicators>[
                   ShowingTooltipIndicators(<LineBarSpot>[
@@ -565,7 +654,7 @@ class _CustomLineChartState extends State<CustomLineChart> {
                 ),
           ],
         ),
-        duration: TraleTheme.of(context)!.transitionDuration.slow,
+        duration: Duration.zero,
         curve: Curves.easeOut,
       );
     }
@@ -596,37 +685,31 @@ class _CustomLineChartState extends State<CustomLineChart> {
 
     void dragUpdate(DragUpdateDetails dragUpdDet) {
       if (!widget.isPreview) {
-        setState(() {
-          _isDragging = true;
-          final double primDelta =
-              (dragUpdDet.primaryDelta ?? 0.0) * (maxX - minX) / 100;
-
-          final double range = maxX - minX;
-          final double dataMaxX =
-              interpolTimes.last > DateTime.now().millisecondsSinceEpoch
-              ? interpolTimes.last
-              : DateTime.now().millisecondsSinceEpoch.toDouble();
-          // Allow scrolling until the first/last interpolation point is
-          // centred in the visible window.
-          final double allowedMaxX = dataMaxX + range / 2;
-          final double allowedMinX = interpolTimes.first - range / 2;
-          final double newMaxX = (maxX - primDelta).clamp(
-            allowedMinX + range,
-            allowedMaxX,
-          );
-          maxX = newMaxX;
-          minX = newMaxX - range;
-        });
+        _tooltipTimer?.cancel();
+        _showTooltip = true;
+        final double primDelta =
+            (dragUpdDet.primaryDelta ?? 0.0) * (maxX - minX) / 100;
+        final double range = maxX - minX;
+        final double dataMaxX =
+            interpolTimes.last > DateTime.now().millisecondsSinceEpoch
+            ? interpolTimes.last
+            : DateTime.now().millisecondsSinceEpoch.toDouble();
+        // Allow scrolling until the first/last interpolation point is
+        // centred in the visible window.
+        final double allowedMaxX = dataMaxX + range / 2;
+        final double allowedMinX = interpolTimes.first - range / 2;
+        final double newMaxX = (maxX - primDelta).clamp(
+          allowedMinX + range,
+          allowedMaxX,
+        );
+        _animateTo(newMaxX - range, newMaxX);
       }
     }
 
     void doubleTap() {
       if (!widget.isPreview) {
         notifier.nextZoomLevel();
-        setState(() {
-          maxX = notifier.zoomLevel.maxX;
-          minX = notifier.zoomLevel.minX;
-        });
+        _animateTo(notifier.zoomLevel.minX, notifier.zoomLevel.maxX);
       }
     }
 
@@ -648,9 +731,19 @@ class _CustomLineChartState extends State<CustomLineChart> {
               onDoubleTap: doubleTap,
               //onScaleUpdate: scaleUpdate,
               onHorizontalDragUpdate: dragUpdate,
-              onHorizontalDragEnd: (_) => setState(() => _isDragging = false),
-              onHorizontalDragCancel: () => setState(() => _isDragging = false),
-              child: lineChart(minX, maxX, minY, maxY),
+              onHorizontalDragEnd: (_) {
+                _tooltipTimer?.cancel();
+                _tooltipTimer = Timer(const Duration(seconds: 3), () {
+                  if (mounted) setState(() => _showTooltip = false);
+                });
+              },
+              onHorizontalDragCancel: () {
+                _tooltipTimer?.cancel();
+                _tooltipTimer = Timer(const Duration(seconds: 3), () {
+                  if (mounted) setState(() => _showTooltip = false);
+                });
+              },
+              child: lineChart(_curMinX, _curMaxX, minY, maxY),
             ),
           ),
         ),
@@ -671,10 +764,10 @@ class _CustomLineChartState extends State<CustomLineChart> {
                             ? null
                             : () {
                                 notifier.zoomOut();
-                                setState(() {
-                                  maxX = notifier.zoomLevel.maxX;
-                                  minX = notifier.zoomLevel.minX;
-                                });
+                                _animateTo(
+                                  notifier.zoomLevel.minX,
+                                  notifier.zoomLevel.maxX,
+                                );
                               },
                         icon: PPIcon(
                           PhosphorIconsDuotone.magnifyingGlassMinus,
@@ -688,10 +781,10 @@ class _CustomLineChartState extends State<CustomLineChart> {
                             ? null
                             : () {
                                 notifier.zoomIn();
-                                setState(() {
-                                  maxX = notifier.zoomLevel.maxX;
-                                  minX = notifier.zoomLevel.minX;
-                                });
+                                _animateTo(
+                                  notifier.zoomLevel.minX,
+                                  notifier.zoomLevel.maxX,
+                                );
                               },
                         icon: PPIcon(
                           PhosphorIconsDuotone.magnifyingGlassPlus,

--- a/app/lib/widget/statsRangeDialog.dart
+++ b/app/lib/widget/statsRangeDialog.dart
@@ -5,6 +5,7 @@ import 'package:provider/provider.dart';
 
 import 'package:trale/core/icons.dart';
 import 'package:trale/core/measurementDatabase.dart';
+import 'package:trale/core/measurementStats.dart';
 import 'package:trale/core/preferences.dart';
 import 'package:trale/core/stats_range.dart';
 import 'package:trale/core/theme.dart';
@@ -39,15 +40,11 @@ Future<bool> showStatsRangeDialog({required BuildContext context}) async {
       } else {
         resolvedDates = selectedRange.dates;
       }
-      final DateTime effectiveFrom =
-          resolvedDates.from ?? db.firstDate;
-      final DateTime effectiveTo =
-          resolvedDates.to ?? DateTime.now();
+      final DateTime effectiveFrom = resolvedDates.from ?? db.firstDate;
+      final DateTime effectiveTo = resolvedDates.to ?? DateTime.now();
 
-      final String fromStr =
-          notifier.dateFormat(context).format(effectiveFrom);
-      final String toStr =
-          notifier.dateFormat(context).format(effectiveTo);
+      final String fromStr = notifier.dateFormat(context).format(effectiveFrom);
+      final String toStr = notifier.dateFormat(context).format(effectiveTo);
 
       return Column(
         mainAxisSize: MainAxisSize.min,
@@ -104,10 +101,9 @@ Future<bool> showStatsRangeDialog({required BuildContext context}) async {
                 onTap: isCustom
                     ? () async {
                         final DateTime now = DateTime.now();
-                        final DateTime lastDate =
-                            customTo != null
-                                ? customTo!.subtract(const Duration(days: 1))
-                                : now;
+                        final DateTime lastDate = customTo != null
+                            ? customTo!.subtract(const Duration(days: 1))
+                            : now;
                         final DateTime? selected = await showDatePicker(
                           context: context,
                           initialDate: customFrom ?? db.firstDate,
@@ -137,10 +133,9 @@ Future<bool> showStatsRangeDialog({required BuildContext context}) async {
                 onTap: isCustom
                     ? () async {
                         final DateTime now = DateTime.now();
-                        final DateTime firstDate =
-                            customFrom != null
-                                ? customFrom!.add(const Duration(days: 1))
-                                : db.firstDate;
+                        final DateTime firstDate = customFrom != null
+                            ? customFrom!.add(const Duration(days: 1))
+                            : db.firstDate;
                         final DateTime? selected = await showDatePicker(
                           context: context,
                           initialDate: customTo ?? now,
@@ -198,6 +193,7 @@ Future<bool> showStatsRangeDialog({required BuildContext context}) async {
                     prefs.statsRangeFrom = customFrom;
                     prefs.statsRangeTo = customTo;
                   }
+                  MeasurementStats().reinit();
                   MeasurementDatabase().fireStream();
                   Navigator.pop(context, true);
                 },

--- a/app/lib/widget/statsRangeDialog.dart
+++ b/app/lib/widget/statsRangeDialog.dart
@@ -1,0 +1,218 @@
+// ignore_for_file: file_names
+import 'package:flutter/material.dart';
+import 'package:phosphor_flutter/phosphor_flutter.dart';
+import 'package:provider/provider.dart';
+
+import 'package:trale/core/icons.dart';
+import 'package:trale/core/measurementDatabase.dart';
+import 'package:trale/core/preferences.dart';
+import 'package:trale/core/stats_range.dart';
+import 'package:trale/core/theme.dart';
+import 'package:trale/core/traleNotifier.dart';
+import 'package:trale/l10n-gen/app_localizations.dart';
+import 'package:trale/widget/dialog.dart';
+import 'package:trale/widget/tile_group.dart';
+
+/// Shows a dialog to select the stats range and optional custom dates.
+Future<bool> showStatsRangeDialog({required BuildContext context}) async {
+  final Preferences prefs = Preferences();
+  final MeasurementDatabase db = MeasurementDatabase();
+  final TraleNotifier notifier = Provider.of<TraleNotifier>(
+    context,
+    listen: false,
+  );
+
+  StatsRange selectedRange = prefs.statsRange;
+  DateTime? customFrom = prefs.statsRangeFrom;
+  DateTime? customTo = prefs.statsRangeTo;
+
+  final Widget content = StatefulBuilder(
+    builder: (BuildContext context, StateSetter setState) {
+      final double padding = TraleTheme.of(context)!.padding;
+      final Color tileColor = Theme.of(context).colorScheme.surfaceContainerLow;
+      final bool isCustom = selectedRange == StatsRange.custom;
+
+      // Resolve effective dates for the selected range
+      final ({DateTime? from, DateTime? to}) resolvedDates;
+      if (isCustom) {
+        resolvedDates = (from: customFrom, to: customTo);
+      } else {
+        resolvedDates = selectedRange.dates;
+      }
+      final DateTime effectiveFrom =
+          resolvedDates.from ?? db.firstDate;
+      final DateTime effectiveTo =
+          resolvedDates.to ?? DateTime.now();
+
+      final String fromStr =
+          notifier.dateFormat(context).format(effectiveFrom);
+      final String toStr =
+          notifier.dateFormat(context).format(effectiveTo);
+
+      return Column(
+        mainAxisSize: MainAxisSize.min,
+        children: <Widget>[
+          WidgetGroup(
+            title: AppLocalizations.of(context)!.statsRange,
+            children: <Widget>[
+              RadioGroup<StatsRange>(
+                groupValue: selectedRange,
+                onChanged: (StatsRange? value) {
+                  if (value != null) {
+                    setState(() => selectedRange = value);
+                  }
+                },
+                child: Column(
+                  mainAxisSize: MainAxisSize.min,
+                  children: <Widget>[
+                    for (final StatsRange range in StatsRange.values)
+                      GroupedRadioListTile<StatsRange>(
+                        color: tileColor,
+                        title: Text(range.nameLong(context)),
+                        value: range,
+                      ),
+                  ],
+                ),
+              ),
+            ],
+          ),
+          SizedBox(height: padding),
+          WidgetGroup(
+            title: AppLocalizations.of(context)!.dates,
+            children: <Widget>[
+              if (isCustom)
+                GroupedText(
+                  color: tileColor,
+                  text: Text(
+                    AppLocalizations.of(context)!.customDateHint,
+                    style: Theme.of(context).textTheme.bodySmall?.copyWith(
+                      color: Theme.of(context).colorScheme.onSurfaceVariant,
+                    ),
+                  ),
+                ),
+              GroupedListTile(
+                color: tileColor,
+                enabled: isCustom,
+                leading: PPIcon(PhosphorIconsDuotone.calendar, context),
+                title: Text(AppLocalizations.of(context)!.from),
+                trailing: Text(
+                  fromStr,
+                  style: Theme.of(context).textTheme.bodyLarge?.copyWith(
+                    color: isCustom ? null : Theme.of(context).disabledColor,
+                  ),
+                ),
+                onTap: isCustom
+                    ? () async {
+                        final DateTime now = DateTime.now();
+                        final DateTime lastDate =
+                            customTo != null
+                                ? customTo!.subtract(const Duration(days: 1))
+                                : now;
+                        final DateTime? selected = await showDatePicker(
+                          context: context,
+                          initialDate: customFrom ?? db.firstDate,
+                          firstDate: db.firstDate,
+                          lastDate: lastDate,
+                        );
+                        if (selected != null) {
+                          setState(() => customFrom = selected);
+                        }
+                      }
+                    : null,
+                onLongPress: isCustom
+                    ? () => setState(() => customFrom = null)
+                    : null,
+              ),
+              GroupedListTile(
+                color: tileColor,
+                enabled: isCustom,
+                leading: PPIcon(PhosphorIconsDuotone.calendarCheck, context),
+                title: Text(AppLocalizations.of(context)!.to),
+                trailing: Text(
+                  toStr,
+                  style: Theme.of(context).textTheme.bodyLarge?.copyWith(
+                    color: isCustom ? null : Theme.of(context).disabledColor,
+                  ),
+                ),
+                onTap: isCustom
+                    ? () async {
+                        final DateTime now = DateTime.now();
+                        final DateTime firstDate =
+                            customFrom != null
+                                ? customFrom!.add(const Duration(days: 1))
+                                : db.firstDate;
+                        final DateTime? selected = await showDatePicker(
+                          context: context,
+                          initialDate: customTo ?? now,
+                          firstDate: firstDate,
+                          lastDate: now,
+                        );
+                        if (selected != null) {
+                          setState(() => customTo = selected);
+                        }
+                      }
+                    : null,
+                onLongPress: isCustom
+                    ? () => setState(() => customTo = null)
+                    : null,
+              ),
+            ],
+          ),
+        ],
+      );
+    },
+  );
+
+  final bool accepted =
+      await showDialog<bool>(
+        barrierDismissible: false,
+        context: context,
+        builder: (BuildContext context) {
+          return DialogM3E(
+            title: AppLocalizations.of(context)!.statsRange,
+            content: SizedBox(
+              width: MediaQuery.of(context).size.width,
+              child: content,
+            ),
+            actions: <Widget>[
+              FilledButton.icon(
+                onPressed: () => Navigator.pop(context, false),
+                style: FilledButton.styleFrom(
+                  backgroundColor: Theme.of(
+                    context,
+                  ).colorScheme.surfaceContainerLow,
+                  foregroundColor: Theme.of(context).colorScheme.onSurface,
+                ),
+                icon: PPIcon(PhosphorIconsRegular.x, context),
+                label: Text(
+                  AppLocalizations.of(context)!.abort,
+                  style: Theme.of(context).textTheme.labelLarge!.copyWith(
+                    color: Theme.of(context).colorScheme.onSurface,
+                  ),
+                ),
+              ),
+              FilledButton.icon(
+                onPressed: () {
+                  prefs.statsRange = selectedRange;
+                  if (selectedRange == StatsRange.custom) {
+                    prefs.statsRangeFrom = customFrom;
+                    prefs.statsRangeTo = customTo;
+                  }
+                  MeasurementDatabase().fireStream();
+                  Navigator.pop(context, true);
+                },
+                icon: PPIcon(PhosphorIconsFill.floppyDiskBack, context),
+                label: Text(
+                  AppLocalizations.of(context)!.save,
+                  style: Theme.of(context).textTheme.labelLarge!.copyWith(
+                    color: Theme.of(context).colorScheme.onPrimary,
+                  ),
+                ),
+              ),
+            ],
+          );
+        },
+      ) ??
+      false;
+  return accepted;
+}

--- a/app/lib/widget/statsWidgets.dart
+++ b/app/lib/widget/statsWidgets.dart
@@ -9,8 +9,6 @@ import 'package:provider/provider.dart';
 import 'package:trale/core/durationExtension.dart';
 import 'package:trale/core/font.dart';
 import 'package:trale/core/gap.dart';
-import 'package:trale/core/measurementDatabase.dart';
-import 'package:trale/core/measurementInterpolation.dart';
 import 'package:trale/core/measurementStats.dart';
 import 'package:trale/core/textSize.dart';
 import 'package:trale/core/theme.dart';
@@ -79,8 +77,6 @@ class _AnimatedStatsWidgetsState extends State<AnimatedStatsWidgets> {
 
   @override
   Widget build(BuildContext context) {
-    final MeasurementInterpolation ip = MeasurementInterpolation();
-    final MeasurementDatabase db = MeasurementDatabase();
     final MeasurementStats stats = MeasurementStats();
     final TraleNotifier notifier = Provider.of<TraleNotifier>(context);
 
@@ -89,7 +85,7 @@ class _AnimatedStatsWidgetsState extends State<AnimatedStatsWidgets> {
       userTargetWeight,
       notifier.looseWeight,
     );
-    final int nMeasured = db.measurementDuration.inDays;
+    final int nMeasured = stats.nMeasurements;
     _ensureWeightLostCardVisibility(nMeasured >= 2);
     Card userTargetWeightCard(double utw) => Card(
       shape: const StadiumBorder(),
@@ -121,7 +117,7 @@ class _AnimatedStatsWidgetsState extends State<AnimatedStatsWidgets> {
     );
 
     Card userWeightLostCard() {
-      final double deltaWeight = ip.finalSlope * 30;
+      final double deltaWeight = stats.monthlyChange;
 
       return Card(
         shape: const StadiumBorder(),

--- a/app/lib/widget/statsWidgets.dart
+++ b/app/lib/widget/statsWidgets.dart
@@ -4,6 +4,7 @@ import 'dart:math';
 
 import 'package:flutter/material.dart';
 import 'package:flutter_auto_size_text/flutter_auto_size_text.dart';
+import 'package:flutter_m3shapes_extended/flutter_m3shapes_extended.dart';
 import 'package:phosphor_flutter/phosphor_flutter.dart';
 import 'package:provider/provider.dart';
 import 'package:trale/core/durationExtension.dart';
@@ -16,8 +17,8 @@ import 'package:trale/core/traleNotifier.dart';
 import 'package:trale/core/units.dart';
 import 'package:trale/l10n-gen/app_localizations.dart';
 import 'package:trale/widget/animate_in_effect.dart';
+import 'package:trale/widget/bento_card.dart';
 import 'package:trale/widget/iconHero.dart';
-import 'package:trale/widget/statsCards.dart';
 
 /// Animated statistics widgets container.
 class AnimatedStatsWidgets extends StatefulWidget {
@@ -209,217 +210,38 @@ class _AnimatedStatsWidgetsState extends State<AnimatedStatsWidgets> {
   }
 }
 
-/// define StatCard for number of days until target weight is reached
-StatCard getReachingTargetWeightWidget({
+// ---------------------------------------------------------------------------
+// BentoCard-based widget builders
+// ---------------------------------------------------------------------------
+
+/// Brightness-aware primary background color.
+Color _primaryBg(BuildContext context) =>
+    Theme.of(context).brightness == Brightness.light
+    ? Theme.of(context).primaryColor
+    : Theme.of(context).colorScheme.primaryContainer;
+
+/// Brightness-aware primary foreground color.
+Color _primaryFg(BuildContext context) =>
+    Theme.of(context).brightness == Brightness.light
+    ? Theme.of(context).colorScheme.onPrimary
+    : Theme.of(context).colorScheme.onPrimaryContainer;
+
+/// Full-width change-rates card (week / month / year columns).
+BentoCard changeRatesCard({
   required BuildContext context,
   required MeasurementStats stats,
-  int? delayInMilliseconds,
-}) {
-  final double? userTargetWeight = Provider.of<TraleNotifier>(
-    context,
-  ).effectiveTargetWeight;
-  final TraleNotifier notifier = Provider.of<TraleNotifier>(context);
-  final Duration? timeOfTargetWeight = stats.timeOfTargetWeight(
-    userTargetWeight,
-    notifier.looseWeight,
-  );
-
-  final List<String> textLabels =
-      (timeOfTargetWeight?.durationToString(context) ??
-              '-- ${AppLocalizations.of(context)!.days}')
-          .split(' ');
-
-  final String subtext = textLabels.length == 1
-      ? AppLocalizations.of(context)!.targetWeightReached
-      : '${textLabels[1]} '
-            '${AppLocalizations.of(context)!.targetWeightReachedIn}';
-
-  return StatCard(
-    backgroundColor: Theme.of(context).brightness == Brightness.light
-        ? Theme.of(context).primaryColor
-        : Theme.of(context).colorScheme.primaryContainer,
-    delayInMilliseconds: delayInMilliseconds,
-    ny: 2,
-    childWidget: Padding(
-      padding: EdgeInsets.all(TraleTheme.of(context)!.padding / 2),
-      child: Column(
-        mainAxisAlignment: MainAxisAlignment.center,
-        children: <Widget>[
-          Expanded(
-            flex: 2,
-            child: Align(
-              alignment: Alignment.center,
-              child: AutoSizeText(
-                textLabels[0],
-                style: Theme.of(context).textTheme.emphasized.displayLarge!
-                    .copyWith(
-                      color: Theme.of(context).brightness == Brightness.light
-                          ? Theme.of(context).colorScheme.onPrimary
-                          : Theme.of(context).colorScheme.onPrimaryContainer,
-                      fontWeight: FontWeight.w700,
-                      fontSize: 200,
-                    ),
-                maxLines: 1,
-              ),
-            ),
-          ),
-          Expanded(
-            flex: 1,
-            child: Align(
-              alignment: Alignment.topCenter,
-              child: AutoSizeText(
-                subtext,
-                style: Theme.of(context).textTheme.bodyLarge!.copyWith(
-                  color: Theme.of(context).brightness == Brightness.light
-                      ? Theme.of(context).colorScheme.onPrimary
-                      : Theme.of(context).colorScheme.onPrimaryContainer,
-                  height: 1.0,
-                ),
-                maxLines: 3,
-                textAlign: TextAlign.center,
-              ),
-            ),
-          ),
-        ],
-      ),
-    ),
-  );
-}
-
-/// define StatCard for the frequency in total
-StatCard getCurrentStreak({
-  required BuildContext context,
-  required MeasurementStats stats,
-  int? delayInMilliseconds,
-}) {
-  return StatCard(
-    backgroundColor: Theme.of(context).brightness == Brightness.light
-        ? Theme.of(context).primaryColor
-        : Theme.of(context).colorScheme.primaryContainer,
-    delayInMilliseconds: delayInMilliseconds,
-    ny: 2,
-    childWidget: Padding(
-      padding: EdgeInsets.all(TraleTheme.of(context)!.padding / 2),
-      child: Column(
-        mainAxisAlignment: MainAxisAlignment.center,
-        children: <Widget>[
-          Expanded(
-            flex: 2,
-            child: Align(
-              alignment: Alignment.center,
-              child: AutoSizeText(
-                stats.globalCurrentStreak.streakToStringDays(
-                  context,
-                  addLabel: false,
-                ),
-                style: Theme.of(context).textTheme.emphasized.displayLarge!
-                    .copyWith(
-                      color: Theme.of(context).brightness == Brightness.light
-                          ? Theme.of(context).colorScheme.onPrimary
-                          : Theme.of(context).colorScheme.onPrimaryContainer,
-                      fontWeight: FontWeight.w700,
-                      fontSize: 200,
-                    ),
-                maxLines: 1,
-              ),
-            ),
-          ),
-          Expanded(
-            flex: 1,
-            child: Align(
-              alignment: Alignment.topCenter,
-              child: AutoSizeText(
-                '${AppLocalizations.of(context)!.currentStreak}\n'
-                '(/ ${AppLocalizations.of(context)!.days})',
-                style: Theme.of(context).textTheme.bodyLarge!.copyWith(
-                  color: Theme.of(context).brightness == Brightness.light
-                      ? Theme.of(context).colorScheme.onPrimary
-                      : Theme.of(context).colorScheme.onPrimaryContainer,
-                  height: 1.0,
-                ),
-                maxLines: 3,
-                textAlign: TextAlign.center,
-              ),
-            ),
-          ),
-        ],
-      ),
-    ),
-  );
-}
-
-/// define StatCard for number of days until target weight is reached
-StatCard getTotalChangeWidget({
-  required BuildContext context,
-  required MeasurementStats stats,
-  int? delayInMilliseconds,
+  int delayInMilliseconds = 0,
 }) {
   final String unit = Provider.of<TraleNotifier>(
     context,
     listen: false,
   ).unit.name;
-  return StatCard(
-    ny: 2,
+  final AppLocalizations l10n = AppLocalizations.of(context)!;
+  return BentoCard(
+    columnSpan: 12,
+    rowSpan: 3,
     delayInMilliseconds: delayInMilliseconds,
-    backgroundColor: Theme.of(context).colorScheme.tertiaryContainer,
-    childWidget: Padding(
-      padding: EdgeInsets.all(TraleTheme.of(context)!.padding / 2),
-      child: Column(
-        mainAxisAlignment: MainAxisAlignment.center,
-        children: <Widget>[
-          Expanded(
-            flex: 3,
-            child: Align(
-              alignment: Alignment.center,
-              child: AutoSizeText(
-                weightToString(context, stats.deltaWeight),
-                style: Theme.of(context).textTheme.emphasized.displayLarge!
-                    .copyWith(
-                      color: Theme.of(context).colorScheme.onTertiaryContainer,
-                      fontWeight: FontWeight.w900,
-                      fontSize: 200,
-                    ),
-                maxLines: 1,
-              ),
-            ),
-          ),
-          Expanded(
-            flex: 1,
-            child: Align(
-              alignment: Alignment.topCenter,
-              child: AutoSizeText(
-                '${AppLocalizations.of(context)!.totalChange}\n($unit)',
-                style: Theme.of(context).textTheme.bodyLarge!.copyWith(
-                  color: Theme.of(context).colorScheme.onTertiaryContainer,
-                  height: 1.0,
-                ),
-                maxLines: 2,
-                textAlign: TextAlign.center,
-              ),
-            ),
-          ),
-        ],
-      ),
-    ),
-  );
-}
-
-/// define StatCard for number of days until target weight is reached
-Widget getMeanWidget({
-  required BuildContext context,
-  required MeasurementStats stats,
-  int? delayInMilliseconds,
-}) {
-  final String unit = Provider.of<TraleNotifier>(
-    context,
-    listen: false,
-  ).unit.name;
-  return StatCard(
-    nx: 2,
-    backgroundColor: Theme.of(context).colorScheme.primaryContainer,
-    delayInMilliseconds: delayInMilliseconds,
-    pillShape: true,
-    childWidget: Row(
+    child: Row(
       mainAxisAlignment: MainAxisAlignment.center,
       children: <Widget>[
         Expanded(
@@ -427,102 +249,7 @@ Widget getMeanWidget({
           child: Align(
             alignment: Alignment.center,
             child: AutoSizeText(
-              weightToString(context, stats.meanWeight),
-              style: Theme.of(context).textTheme.emphasized.displayLarge!
-                  .copyWith(
-                    color: Theme.of(context).colorScheme.onPrimaryContainer,
-                    fontWeight: FontWeight.w900,
-                    fontSize: 200,
-                  ),
-              maxLines: 1,
-            ),
-          ),
-        ),
-        Expanded(
-          flex: 1,
-          child: Align(
-            alignment: Alignment.center,
-            child: AutoSizeText(
-              '${AppLocalizations.of(context)!.mean} ($unit)',
-              style: Theme.of(context).textTheme.bodyMedium!.copyWith(
-                color: Theme.of(context).colorScheme.onPrimaryContainer,
-                height: 1.0,
-              ),
-              maxLines: 2,
-              textAlign: TextAlign.center,
-            ),
-          ),
-        ),
-      ],
-    ),
-  );
-}
-
-/// define StatCard for number of days until target weight is reached
-Widget getBMIWidget({
-  required BuildContext context,
-  required MeasurementStats stats,
-  int? delayInMilliseconds,
-}) {
-  return StatCard(
-    nx: 2,
-    delayInMilliseconds: delayInMilliseconds,
-    childWidget: Row(
-      mainAxisAlignment: MainAxisAlignment.center,
-      children: <Widget>[
-        Expanded(
-          flex: 1,
-          child: Align(
-            alignment: Alignment.center,
-            child: AutoSizeText(
-              AppLocalizations.of(context)!.bmi,
-              style: Theme.of(
-                context,
-              ).textTheme.bodyMedium!.copyWith(height: 1.0),
-              maxLines: 2,
-              textAlign: TextAlign.center,
-            ),
-          ),
-        ),
-        Expanded(
-          flex: 2,
-          child: Align(
-            alignment: Alignment.center,
-            child: AutoSizeText(
-              doubleToString(stats.currentBMI(context)),
-              style: Theme.of(context).textTheme.emphasized.displayLarge!
-                  .copyWith(fontWeight: FontWeight.w900, fontSize: 200),
-              maxLines: 1,
-            ),
-          ),
-        ),
-      ],
-    ),
-  );
-}
-
-/// define StatCard for change per week, month, and year
-StatCard getChangeRatesWidget({
-  required BuildContext context,
-  required MeasurementStats stats,
-  int? delayInMilliseconds,
-}) {
-  final String unit = Provider.of<TraleNotifier>(
-    context,
-    listen: false,
-  ).unit.name;
-  return StatCard(
-    nx: 2,
-    delayInMilliseconds: delayInMilliseconds,
-    childWidget: Row(
-      mainAxisAlignment: MainAxisAlignment.center,
-      children: <Widget>[
-        Expanded(
-          flex: 2,
-          child: Align(
-            alignment: Alignment.center,
-            child: AutoSizeText(
-              '${AppLocalizations.of(context)!.change} ($unit)',
+              '${l10n.change} ($unit)',
               style: Theme.of(context).textTheme.emphasized.bodyLarge!
                   .onSurface(context)
                   .copyWith(fontWeight: FontWeight.w900),
@@ -532,12 +259,10 @@ StatCard getChangeRatesWidget({
           ),
         ),
         Expanded(
-          flex: 1,
           child: Align(
             alignment: Alignment.centerLeft,
             child: AutoSizeText(
-              '/ ${AppLocalizations.of(context)!.week}\n'
-              '${weightToString(context, stats.deltaWeightLastWeek)}',
+              '/ ${l10n.week}\n${weightToString(context, stats.deltaWeightLastWeek)}',
               style: Theme.of(
                 context,
               ).textTheme.bodyMedium!.onSurface(context).copyWith(height: 1.0),
@@ -547,12 +272,10 @@ StatCard getChangeRatesWidget({
           ),
         ),
         Expanded(
-          flex: 1,
           child: Align(
             alignment: Alignment.centerLeft,
             child: AutoSizeText(
-              '/ ${AppLocalizations.of(context)!.month}\n'
-              '${weightToString(context, stats.deltaWeightLastMonth)}',
+              '/ ${l10n.month}\n${weightToString(context, stats.deltaWeightLastMonth)}',
               style: Theme.of(
                 context,
               ).textTheme.bodyMedium!.onSurface(context).copyWith(height: 1.0),
@@ -562,12 +285,10 @@ StatCard getChangeRatesWidget({
           ),
         ),
         Expanded(
-          flex: 1,
           child: Align(
             alignment: Alignment.centerLeft,
             child: AutoSizeText(
-              '/ ${AppLocalizations.of(context)!.year}\n'
-              '${weightToString(context, stats.deltaWeightLastYear)}',
+              '/ ${l10n.year}\n${weightToString(context, stats.deltaWeightLastYear)}',
               style: Theme.of(
                 context,
               ).textTheme.bodyMedium!.onSurface(context).copyWith(height: 1.0),
@@ -581,133 +302,263 @@ StatCard getChangeRatesWidget({
   );
 }
 
-/// define StatCard for change per week, month, and year
-Widget getMinWidget({
+/// Hero card: days until target weight is reached (with rotating M3E shape).
+BentoCard reachingTargetWeightCard({
   required BuildContext context,
   required MeasurementStats stats,
-  int? delayInMilliseconds,
+  int delayInMilliseconds = 0,
+}) {
+  final TraleNotifier notifier = Provider.of<TraleNotifier>(
+    context,
+    listen: false,
+  );
+  final Duration? timeOfTargetWeight = stats.timeOfTargetWeight(
+    notifier.effectiveTargetWeight,
+    notifier.looseWeight,
+  );
+  final AppLocalizations l10n = AppLocalizations.of(context)!;
+  final List<String> labels =
+      (timeOfTargetWeight?.durationToString(context) ?? '-- ${l10n.days}')
+          .split(' ');
+  final String subtext = labels.length == 1
+      ? l10n.targetWeightReached
+      : '${labels[1]} ${l10n.targetWeightReachedIn}';
+
+  return BentoCard.hero(
+    span: 6,
+    label: subtext,
+    value: labels[0],
+    textColor: _primaryFg(context),
+    backgroundColor: _primaryBg(context),
+    delayInMilliseconds: delayInMilliseconds,
+    m3eShape: Shapes.sunny,
+    rotateDuration: const Duration(seconds: 60),
+  );
+}
+
+/// Text card: number of total measurements (pill shape).
+BentoCard nMeasurementsCard({
+  required BuildContext context,
+  required MeasurementStats stats,
+  int delayInMilliseconds = 0,
+}) {
+  final String measurementsLabel = AppLocalizations.of(
+    context,
+  )!.measurements.toLowerCase();
+  return BentoCard.text(
+    columnSpan: 6,
+    label: '# $measurementsLabel',
+    value: '${stats.globalNMeasurements}',
+    delayInMilliseconds: delayInMilliseconds,
+    pillShape: true,
+  );
+}
+
+/// Hero card: total weight change.
+BentoCard totalChangeCard({
+  required BuildContext context,
+  required MeasurementStats stats,
+  int delayInMilliseconds = 0,
 }) {
   final String unit = Provider.of<TraleNotifier>(
     context,
     listen: false,
   ).unit.name;
-  return OneThirdStatCard(
+  return BentoCard.hero(
+    span: 6,
+    label: '${AppLocalizations.of(context)!.totalChange}\n($unit)',
+    value: weightToString(context, stats.deltaWeight),
+    valueFlex: 3,
+    textColor: Theme.of(context).colorScheme.onTertiaryContainer,
+    backgroundColor: Theme.of(context).colorScheme.tertiaryContainer,
     delayInMilliseconds: delayInMilliseconds,
-    childWidget: Padding(
-      padding: EdgeInsets.all(TraleTheme.of(context)!.padding / 2),
-      child: Column(
-        mainAxisAlignment: MainAxisAlignment.center,
-        children: <Widget>[
-          Expanded(
-            flex: 1,
-            child: Align(
-              alignment: Alignment.center,
-              child: AutoSizeText(
-                '${AppLocalizations.of(context)!.min} ($unit)',
-                style: Theme.of(
-                  context,
-                ).textTheme.bodyLarge!.onSurface(context),
-                maxLines: 1,
-              ),
-            ),
-          ),
-          Expanded(
-            flex: 2,
-            child: Align(
-              alignment: Alignment.center,
-              child: AutoSizeText(
-                weightToString(context, stats.minWeight),
-                style: Theme.of(context).textTheme.emphasized.bodyMedium!
-                    .onSurface(context)
-                    .copyWith(
-                      fontWeight: FontWeight.w700,
-                      fontSize: 200,
-                      height: 0.70,
-                    ),
-                maxLines: 1,
-              ),
-            ),
-          ),
-        ],
-      ),
-    ),
   );
 }
 
-/// define StatCard for change per week, month, and year
-Widget getMaxWidget({
+/// Inline card: time since first measurement (number on left, label on right).
+BentoCard timeSinceFirstCard({
   required BuildContext context,
   required MeasurementStats stats,
-  int? delayInMilliseconds,
+  int delayInMilliseconds = 0,
+}) {
+  final String durationStr = stats.globalDeltaTime.durationToString(context);
+  final List<String> parts = durationStr.split(' ');
+  final String number = parts[0];
+  final String unit = parts.length > 1 ? parts.sublist(1).join(' ') : '';
+  return BentoCard.textInline(
+    columnSpan: 12,
+    reversed: true,
+    value: number,
+    label: '$unit\n${AppLocalizations.of(context)!.timeSinceFirstMeasurement}',
+    valueFlex: 2,
+    delayInMilliseconds: delayInMilliseconds,
+  );
+}
+
+/// Emphasized-text card: minimum recorded weight (label above, value below).
+BentoCard minWeightCard({
+  required BuildContext context,
+  required MeasurementStats stats,
+  int delayInMilliseconds = 0,
 }) {
   final String unit = Provider.of<TraleNotifier>(
     context,
     listen: false,
   ).unit.name;
-  return OneThirdStatCard(
+  return BentoCard.textEmphasized(
+    columnSpan: 5,
+    rowSpan: 2,
+    label: '${AppLocalizations.of(context)!.min} ($unit)',
+    value: weightToString(context, stats.minWeight),
+    valueFlex: 2,
     delayInMilliseconds: delayInMilliseconds,
-    childWidget: Padding(
-      padding: EdgeInsets.all(TraleTheme.of(context)!.padding / 2),
-      child: Column(
-        mainAxisAlignment: MainAxisAlignment.center,
-        children: <Widget>[
-          Expanded(
-            flex: 2,
-            child: Align(
-              alignment: Alignment.center,
-              child: AutoSizeText(
-                weightToString(context, stats.maxWeight),
-                style: Theme.of(context).textTheme.emphasized.bodyMedium!
-                    .onSurface(context)
-                    .copyWith(
-                      fontWeight: FontWeight.w700,
-                      fontSize: 200,
-                      height: 0.70,
-                    ),
-                maxLines: 1,
-              ),
-            ),
-          ),
-          Expanded(
-            flex: 1,
-            child: Align(
-              alignment: Alignment.center,
-              child: AutoSizeText(
-                '${AppLocalizations.of(context)!.max} ($unit)',
-                style: Theme.of(
-                  context,
-                ).textTheme.bodyLarge!.onSurface(context),
-                maxLines: 1,
-              ),
-            ),
-          ),
-        ],
-      ),
-    ),
   );
 }
 
-/// define StatCard for change per week, month, and year
-Widget getIconWidget({
+/// Transparent card: app icon hero.
+BentoCard iconHeroCard({
+  required BuildContext context,
+  int delayInMilliseconds = 0,
+}) => BentoCard(
+  columnSpan: 2,
+  rowSpan: 2,
+  backgroundColor: Colors.transparent,
+  delayInMilliseconds: delayInMilliseconds,
+  child: const IconHeroStatScreen(),
+);
+
+/// Emphasized-text card: maximum recorded weight (value above, label below).
+BentoCard maxWeightCard({
   required BuildContext context,
   required MeasurementStats stats,
-  int? delayInMilliseconds,
+  int delayInMilliseconds = 0,
 }) {
-  final double iconHeroSize =
-      (MediaQuery.sizeOf(context).width - 5 * TraleTheme.of(context)!.padding) /
-      4;
-  final int animationDurationInMilliseconds = TraleTheme.of(
+  final String unit = Provider.of<TraleNotifier>(
     context,
-  )!.transitionDuration.slow.inMilliseconds;
+    listen: false,
+  ).unit.name;
+  return BentoCard.textEmphasized(
+    columnSpan: 5,
+    rowSpan: 2,
+    reversed: true,
+    label: '${AppLocalizations.of(context)!.max} ($unit)',
+    value: weightToString(context, stats.maxWeight),
+    valueFlex: 2,
+    delayInMilliseconds: delayInMilliseconds,
+  );
+}
 
-  return AnimateInEffect(
-    delayInMilliseconds: delayInMilliseconds ?? 0,
-    durationInMilliseconds: animationDurationInMilliseconds,
-    child: SizedBox(
-      width: iconHeroSize,
-      height: iconHeroSize,
-      child: const IconHeroStatScreen(),
-    ),
+/// Text card: mean weight.
+BentoCard meanWeightCard({
+  required BuildContext context,
+  required MeasurementStats stats,
+  int delayInMilliseconds = 0,
+}) {
+  final String unit = Provider.of<TraleNotifier>(
+    context,
+    listen: false,
+  ).unit.name;
+  return BentoCard.text(
+    columnSpan: 6,
+    rowSpan: 3,
+    label: '${AppLocalizations.of(context)!.mean} ($unit)',
+    value: weightToString(context, stats.meanWeight),
+    delayInMilliseconds: delayInMilliseconds,
+  );
+}
+
+/// Text card: all-time max streak.
+BentoCard maxStreakCard({
+  required BuildContext context,
+  required MeasurementStats stats,
+  int delayInMilliseconds = 0,
+}) => BentoCard.text(
+  columnSpan: 6,
+  label: AppLocalizations.of(context)!.maxStreak,
+  value: stats.globalMaxStreak.streakToStringDays(context),
+  delayInMilliseconds: delayInMilliseconds,
+);
+
+/// Hero card: current streak (with rotating M3E shape).
+BentoCard currentStreakCard({
+  required BuildContext context,
+  required MeasurementStats stats,
+  int delayInMilliseconds = 0,
+}) {
+  final AppLocalizations l10n = AppLocalizations.of(context)!;
+  return BentoCard.hero(
+    span: 6,
+    label: '${l10n.currentStreak}\n(/ ${l10n.days})',
+    value: (stats.globalCurrentStreak + const Duration(days: 120))
+        .streakToStringDays(context, addLabel: false),
+    textColor: _primaryFg(context),
+    backgroundColor: _primaryBg(context),
+    delayInMilliseconds: delayInMilliseconds,
+    m3eShape: Shapes.c12_sided_cookie,
+    rotateDuration: const Duration(seconds: 60),
+  );
+}
+
+/// Text card: measurement frequency per week.
+BentoCard measurementFrequencyCard({
+  required BuildContext context,
+  required MeasurementStats stats,
+  int delayInMilliseconds = 0,
+}) {
+  final AppLocalizations l10n = AppLocalizations.of(context)!;
+  return BentoCard.text(
+    columnSpan: 6,
+    label: '${l10n.measurementFrequency}\n(/ ${l10n.week})',
+    value: stats.globalFrequency!.toStringAsFixed(2),
+    delayInMilliseconds: delayInMilliseconds,
+  );
+}
+
+/// Inline card: current BMI (label on left, value on right).
+BentoCard bmiCard({
+  required BuildContext context,
+  required MeasurementStats stats,
+  int delayInMilliseconds = 0,
+}) => BentoCard.textInline(
+  columnSpan: 12,
+  label: AppLocalizations.of(context)!.bmi,
+  value: doubleToString(stats.currentBMI(context)),
+  delayInMilliseconds: delayInMilliseconds,
+);
+
+/// Text card: estimated daily calorie deficit.
+BentoCard calorieDeficitCard({
+  required BuildContext context,
+  required MeasurementStats stats,
+  int delayInMilliseconds = 0,
+}) => BentoCard.text(
+  columnSpan: 6,
+  rowSpan: 3,
+  label: '${AppLocalizations.of(context)!.calorieDeficit}\n(kcal/day)',
+  value: '${stats.dailyDeficit}',
+  delayInMilliseconds: delayInMilliseconds,
+);
+
+/// Text card: difference from target weight.
+BentoCard diffFromTargetCard({
+  required BuildContext context,
+  required MeasurementStats stats,
+  int delayInMilliseconds = 0,
+}) {
+  final String unit = Provider.of<TraleNotifier>(
+    context,
+    listen: false,
+  ).unit.name;
+  return BentoCard.hero(
+    span: 6,
+    label: '${AppLocalizations.of(context)!.diffFromTarget} ($unit)',
+    value: weightToString(context, stats.currentDifference),
+    valueFlex: 3,
+    textColor: Theme.of(context).colorScheme.onTertiaryContainer,
+    backgroundColor: Theme.of(context).colorScheme.tertiaryContainer,
+    delayInMilliseconds: delayInMilliseconds,
+    m3eShape: Shapes.pill,
+    rotateDuration: const Duration(seconds: 120),
   );
 }
 
@@ -725,31 +576,4 @@ String weightToString(BuildContext context, double? d) {
 /// Converts a double value to a display string.
 String doubleToString(double? d) {
   return d == null ? '--' : d.toStringAsFixed(1);
-}
-
-/// get caloric deficit widget
-Widget getCalorieDeficitWidget({
-  required BuildContext context,
-  required MeasurementStats stats,
-  int? delayInMilliseconds,
-}) => DefaultStatCard(
-  firstRow: '${AppLocalizations.of(context)!.calorieDeficit}\n(kcal/day)',
-  secondRow: '${stats.dailyDeficit}',
-);
-
-/// get caloric deficit widget
-Widget getDiffFromTargetWidget({
-  required BuildContext context,
-  required MeasurementStats stats,
-  int? delayInMilliseconds,
-}) {
-  final String unit = Provider.of<TraleNotifier>(
-    context,
-    listen: false,
-  ).unit.name;
-
-  return DefaultStatCard(
-    firstRow: '${AppLocalizations.of(context)!.diffFromTarget} ($unit)',
-    secondRow: weightToString(context, stats.currentDifference),
-  );
 }

--- a/app/lib/widget/statsWidgets.dart
+++ b/app/lib/widget/statsWidgets.dart
@@ -461,12 +461,159 @@ BentoCard timeSinceFirstCard({
   final List<String> parts = durationStr.split(' ');
   final String number = parts[0];
   final String unit = parts.length > 1 ? parts.sublist(1).join(' ') : '';
-  return BentoCard.textInline(
-    columnSpan: 8,
-    reversed: true,
+  return BentoCard.text(
+    columnSpan: 6,
     value: number,
-    label: '$unit\n${AppLocalizations.of(context)!.timeSinceFirstMeasurement}',
-    valueFlex: 1,
+    label:
+        '${AppLocalizations.of(context)!.timeSinceFirstMeasurement}\n($unit)',
+    delayInMilliseconds: delayInMilliseconds,
+  );
+}
+
+/// Emphasized 4×4 card: all-time weight maximum with the date it was recorded.
+BentoCard globalMaxWeightDateCard({
+  required BuildContext context,
+  required MeasurementStats stats,
+  int delayInMilliseconds = 0,
+}) {
+  final TraleNotifier notifier = Provider.of<TraleNotifier>(
+    context,
+    listen: false,
+  );
+  final ({double? weight, DateTime? date}) record =
+      notifier.statsUseInterpolation
+      ? stats.globalMaxInterpolatedWeightDate
+      : stats.globalMaxWeightDate;
+  final String weightStr = weightToString(context, record.weight);
+  final String dateStr = record.date != null
+      ? notifier.dateFormat(context).format(record.date!)
+      : '--';
+  final String unit = notifier.unit.name;
+  final AppLocalizations l10n = AppLocalizations.of(context)!;
+  return BentoCard(
+    columnSpan: 4,
+    rowSpan: 3,
+    delayInMilliseconds: delayInMilliseconds,
+    child: Padding(
+      padding: EdgeInsets.all(TraleTheme.of(context)!.padding / 2),
+      child: Column(
+        mainAxisAlignment: MainAxisAlignment.center,
+        children: <Widget>[
+          AutoSizeText(
+            '${l10n.max} ($unit)',
+            style: Theme.of(context).textTheme.bodyLarge!.onSurface(context),
+            maxLines: 2,
+            textAlign: TextAlign.center,
+          ),
+          Expanded(
+            child: Align(
+              alignment: Alignment.center,
+              child: AutoSizeText(
+                weightStr,
+                style: Theme.of(context).textTheme.emphasized.bodyMedium!
+                    .onSurface(context)
+                    .copyWith(
+                      fontWeight: FontWeight.w700,
+                      fontSize: 200,
+                      height: 0.7,
+                    ),
+                maxLines: 1,
+              ),
+            ),
+          ),
+          AutoSizeText(
+            dateStr,
+            style: Theme.of(context).textTheme.bodySmall!.onSurface(context),
+            maxLines: 1,
+            textAlign: TextAlign.center,
+          ),
+        ],
+      ),
+    ),
+  );
+}
+
+/// Emphasized 4×4 card: all-time weight minimum with the date it was recorded.
+BentoCard globalMinWeightDateCard({
+  required BuildContext context,
+  required MeasurementStats stats,
+  int delayInMilliseconds = 0,
+}) {
+  final TraleNotifier notifier = Provider.of<TraleNotifier>(
+    context,
+    listen: false,
+  );
+  final ({double? weight, DateTime? date}) record =
+      notifier.statsUseInterpolation
+      ? stats.globalMinInterpolatedWeightDate
+      : stats.globalMinWeightDate;
+  final String weightStr = weightToString(context, record.weight);
+  final String dateStr = record.date != null
+      ? notifier.dateFormat(context).format(record.date!)
+      : '--';
+  final String unit = notifier.unit.name;
+  final AppLocalizations l10n = AppLocalizations.of(context)!;
+  return BentoCard(
+    columnSpan: 4,
+    rowSpan: 3,
+    delayInMilliseconds: delayInMilliseconds,
+    child: Padding(
+      padding: EdgeInsets.all(TraleTheme.of(context)!.padding / 2),
+      child: Column(
+        mainAxisAlignment: MainAxisAlignment.center,
+        children: <Widget>[
+          AutoSizeText(
+            '${l10n.min} ($unit)',
+            style: Theme.of(context).textTheme.bodyLarge!.onSurface(context),
+            maxLines: 2,
+            textAlign: TextAlign.center,
+          ),
+          Expanded(
+            child: Align(
+              alignment: Alignment.center,
+              child: AutoSizeText(
+                weightStr,
+                style: Theme.of(context).textTheme.emphasized.bodyMedium!
+                    .onSurface(context)
+                    .copyWith(
+                      fontWeight: FontWeight.w700,
+                      fontSize: 200,
+                      height: 0.7,
+                    ),
+                maxLines: 1,
+              ),
+            ),
+          ),
+          AutoSizeText(
+            dateStr,
+            style: Theme.of(context).textTheme.bodySmall!.onSurface(context),
+            maxLines: 1,
+            textAlign: TextAlign.center,
+          ),
+        ],
+      ),
+    ),
+  );
+}
+
+/// Text card: median weight.
+BentoCard medianWeightCard({
+  required BuildContext context,
+  required MeasurementStats stats,
+  int delayInMilliseconds = 0,
+}) {
+  final TraleNotifier notifier = Provider.of<TraleNotifier>(
+    context,
+    listen: false,
+  );
+  final double? weight = notifier.statsUseInterpolation
+      ? stats.medianInterpolatedWeight
+      : stats.medianWeight;
+  return BentoCard.text(
+    columnSpan: 6,
+    rowSpan: 3,
+    label: '${AppLocalizations.of(context)!.median} (${notifier.unit.name})',
+    value: weightToString(context, weight),
     delayInMilliseconds: delayInMilliseconds,
   );
 }
@@ -477,15 +624,18 @@ BentoCard minWeightCard({
   required MeasurementStats stats,
   int delayInMilliseconds = 0,
 }) {
-  final String unit = Provider.of<TraleNotifier>(
+  final TraleNotifier notifier = Provider.of<TraleNotifier>(
     context,
     listen: false,
-  ).unit.name;
+  );
+  final double? weight = notifier.statsUseInterpolation
+      ? stats.minInterpolatedWeight
+      : stats.minWeight;
   return BentoCard.textEmphasized(
     columnSpan: 4,
     rowSpan: 3,
-    label: '${AppLocalizations.of(context)!.min} ($unit)',
-    value: weightToString(context, stats.minWeight),
+    label: '${AppLocalizations.of(context)!.min} (${notifier.unit.name})',
+    value: weightToString(context, weight),
     valueFlex: 2,
     delayInMilliseconds: delayInMilliseconds,
   );
@@ -509,16 +659,19 @@ BentoCard maxWeightCard({
   required MeasurementStats stats,
   int delayInMilliseconds = 0,
 }) {
-  final String unit = Provider.of<TraleNotifier>(
+  final TraleNotifier notifier = Provider.of<TraleNotifier>(
     context,
     listen: false,
-  ).unit.name;
+  );
+  final double? weight = notifier.statsUseInterpolation
+      ? stats.maxInterpolatedWeight
+      : stats.maxWeight;
   return BentoCard.textEmphasized(
     columnSpan: 4,
     rowSpan: 3,
     reversed: true,
-    label: '${AppLocalizations.of(context)!.max} ($unit)',
-    value: weightToString(context, stats.maxWeight),
+    label: '${AppLocalizations.of(context)!.max} (${notifier.unit.name})',
+    value: weightToString(context, weight),
     valueFlex: 2,
     delayInMilliseconds: delayInMilliseconds,
   );
@@ -530,15 +683,18 @@ BentoCard meanWeightCard({
   required MeasurementStats stats,
   int delayInMilliseconds = 0,
 }) {
-  final String unit = Provider.of<TraleNotifier>(
+  final TraleNotifier notifier = Provider.of<TraleNotifier>(
     context,
     listen: false,
-  ).unit.name;
+  );
+  final double? weight = notifier.statsUseInterpolation
+      ? stats.meanInterpolatedWeight
+      : stats.meanWeight;
   return BentoCard.text(
     columnSpan: 6,
     rowSpan: 3,
-    label: '${AppLocalizations.of(context)!.mean} ($unit)',
-    value: weightToString(context, stats.meanWeight),
+    label: '${AppLocalizations.of(context)!.mean} (${notifier.unit.name})',
+    value: weightToString(context, weight),
     delayInMilliseconds: delayInMilliseconds,
   );
 }
@@ -592,17 +748,96 @@ BentoCard measurementFrequencyCard({
   );
 }
 
-/// Inline card: current BMI (label on left, value on right).
+/// Returns the BMI range string and category label for a given [bmi] value.
+({String range, String category}) _bmiCategory(
+  double bmi,
+  AppLocalizations l10n,
+) {
+  if (bmi < 17) {
+    return (range: '< 17', category: l10n.bmiSevereUnderweight);
+  } else if (bmi < 18.5) {
+    return (range: '17 – 18.5', category: l10n.bmiUnderweight);
+  } else if (bmi < 25) {
+    return (range: '18.5 – 25', category: l10n.bmiNormal);
+  } else if (bmi < 30) {
+    return (range: '25 – 30', category: l10n.bmiOverweight);
+  } else {
+    return (range: '> 30', category: l10n.bmiObese);
+  }
+}
+
+/// Card: current BMI with value, range, and category.
 BentoCard bmiCard({
   required BuildContext context,
   required MeasurementStats stats,
   int delayInMilliseconds = 0,
-}) => BentoCard.textInline(
-  columnSpan: 12,
-  label: AppLocalizations.of(context)!.bmi,
-  value: doubleToString(stats.currentBMI(context)),
-  delayInMilliseconds: delayInMilliseconds,
-);
+}) {
+  final AppLocalizations l10n = AppLocalizations.of(context)!;
+  final double? bmi = stats.currentBMI(context);
+  final String bmiStr = doubleToString(bmi);
+  final ({String range, String category}) info = bmi != null
+      ? _bmiCategory(bmi, l10n)
+      : (range: '--', category: '--');
+  return BentoCard(
+    columnSpan: 12,
+    rowSpan: 3,
+    delayInMilliseconds: delayInMilliseconds,
+    child: Padding(
+      padding: EdgeInsets.symmetric(
+        horizontal: TraleTheme.of(context)!.padding,
+        vertical: TraleTheme.of(context)!.padding / 2,
+      ),
+      child: Row(
+        mainAxisAlignment: MainAxisAlignment.center,
+        children: <Widget>[
+          Expanded(
+            child: Align(
+              alignment: Alignment.center,
+              child: AutoSizeText(
+                l10n.bmi,
+                style: Theme.of(context).textTheme.emphasized.bodyLarge!
+                    .onSurface(context)
+                    .copyWith(fontWeight: FontWeight.w900),
+                maxLines: 1,
+                textAlign: TextAlign.center,
+              ),
+            ),
+          ),
+          Expanded(
+            flex: 2,
+            child: Align(
+              alignment: Alignment.center,
+              child: AutoSizeText(
+                bmiStr,
+                style: Theme.of(context).textTheme.emphasized.bodyMedium!
+                    .onSurface(context)
+                    .copyWith(
+                      fontWeight: FontWeight.w700,
+                      fontSize: 200,
+                      height: 0.7,
+                    ),
+                maxLines: 1,
+              ),
+            ),
+          ),
+          Expanded(
+            child: Align(
+              alignment: Alignment.center,
+              child: AutoSizeText(
+                '${info.range}\n${info.category}',
+                style: Theme.of(
+                  context,
+                ).textTheme.bodySmall!.onSurface(context),
+                maxLines: 3,
+                textAlign: TextAlign.center,
+              ),
+            ),
+          ),
+        ],
+      ),
+    ),
+  );
+}
 
 /// Text card: estimated daily calorie deficit.
 BentoCard calorieDeficitCard({
@@ -635,8 +870,6 @@ BentoCard diffFromTargetCard({
     textColor: Theme.of(context).colorScheme.onTertiaryContainer,
     backgroundColor: Theme.of(context).colorScheme.tertiaryContainer,
     delayInMilliseconds: delayInMilliseconds,
-    m3eShape: Shapes.l8_leaf_clover,
-    rotateDuration: const Duration(seconds: 40),
   );
 }
 

--- a/app/lib/widget/statsWidgets.dart
+++ b/app/lib/widget/statsWidgets.dart
@@ -287,7 +287,7 @@ StatCard getReachingTargetWeightWidget({
 }
 
 /// define StatCard for the frequency in total
-StatCard getFrequencyInTotal({
+StatCard getCurrentStreak({
   required BuildContext context,
   required MeasurementStats stats,
   int? delayInMilliseconds,
@@ -308,7 +308,10 @@ StatCard getFrequencyInTotal({
             child: Align(
               alignment: Alignment.center,
               child: AutoSizeText(
-                (7 * stats.frequencyInTotal!).toStringAsFixed(2),
+                stats.currentStreak.streakToStringDays(
+                  context,
+                  addLabel: false,
+                ),
                 style: Theme.of(context).textTheme.emphasized.displayLarge!
                     .copyWith(
                       color: Theme.of(context).brightness == Brightness.light
@@ -326,8 +329,8 @@ StatCard getFrequencyInTotal({
             child: Align(
               alignment: Alignment.topCenter,
               child: AutoSizeText(
-                '${AppLocalizations.of(context)!.measurementFrequency}\n'
-                '(/ ${AppLocalizations.of(context)!.week})',
+                '${AppLocalizations.of(context)!.currentStreak}\n'
+                '(/ ${AppLocalizations.of(context)!.days})',
                 style: Theme.of(context).textTheme.bodyLarge!.copyWith(
                   color: Theme.of(context).brightness == Brightness.light
                       ? Theme.of(context).colorScheme.onPrimary

--- a/app/lib/widget/statsWidgets.dart
+++ b/app/lib/widget/statsWidgets.dart
@@ -565,8 +565,10 @@ BentoCard currentStreakCard({
   return BentoCard.hero(
     span: 6,
     label: '${l10n.currentStreak}\n(/ ${l10n.days})',
-    value: (stats.globalCurrentStreak + const Duration(days: 120))
-        .streakToStringDays(context, addLabel: false),
+    value: stats.globalCurrentStreak.streakToStringDays(
+      context,
+      addLabel: false,
+    ),
     textColor: _primaryFg(context),
     backgroundColor: _primaryBg(context),
     delayInMilliseconds: delayInMilliseconds,
@@ -628,7 +630,7 @@ BentoCard diffFromTargetCard({
   return BentoCard.hero(
     span: 6,
     label: '${AppLocalizations.of(context)!.diffFromTarget} ($unit)',
-    value: '2', //weightToString(context, stats.currentDifference),
+    value: weightToString(context, stats.currentDifference),
     valueFlex: 3,
     textColor: Theme.of(context).colorScheme.onTertiaryContainer,
     backgroundColor: Theme.of(context).colorScheme.tertiaryContainer,

--- a/app/lib/widget/statsWidgets.dart
+++ b/app/lib/widget/statsWidgets.dart
@@ -726,3 +726,30 @@ String weightToString(BuildContext context, double? d) {
 String doubleToString(double? d) {
   return d == null ? '--' : d.toStringAsFixed(1);
 }
+
+/// get caloric deficit widget
+Widget getCalorieDeficitWidget({
+  required BuildContext context,
+  required MeasurementStats stats,
+  int? delayInMilliseconds,
+}) => DefaultStatCard(
+  firstRow: '${AppLocalizations.of(context)!.calorieDeficit}\n(kcal/day)',
+  secondRow: '${stats.dailyDeficit}',
+);
+
+/// get caloric deficit widget
+Widget getDiffFromTargetWidget({
+  required BuildContext context,
+  required MeasurementStats stats,
+  int? delayInMilliseconds,
+}) {
+  final String unit = Provider.of<TraleNotifier>(
+    context,
+    listen: false,
+  ).unit.name;
+
+  return DefaultStatCard(
+    firstRow: '${AppLocalizations.of(context)!.diffFromTarget} ($unit)',
+    secondRow: weightToString(context, stats.currentDifference),
+  );
+}

--- a/app/lib/widget/statsWidgets.dart
+++ b/app/lib/widget/statsWidgets.dart
@@ -9,6 +9,7 @@ import 'package:provider/provider.dart';
 import 'package:trale/core/durationExtension.dart';
 import 'package:trale/core/font.dart';
 import 'package:trale/core/gap.dart';
+import 'package:trale/core/measurementDatabase.dart';
 import 'package:trale/core/measurementInterpolation.dart';
 import 'package:trale/core/measurementStats.dart';
 import 'package:trale/core/textSize.dart';
@@ -79,6 +80,7 @@ class _AnimatedStatsWidgetsState extends State<AnimatedStatsWidgets> {
   @override
   Widget build(BuildContext context) {
     final MeasurementInterpolation ip = MeasurementInterpolation();
+    final MeasurementDatabase db = MeasurementDatabase();
     final MeasurementStats stats = MeasurementStats();
     final TraleNotifier notifier = Provider.of<TraleNotifier>(context);
 
@@ -87,7 +89,7 @@ class _AnimatedStatsWidgetsState extends State<AnimatedStatsWidgets> {
       userTargetWeight,
       notifier.looseWeight,
     );
-    final int nMeasured = ip.measurementDuration.inDays;
+    final int nMeasured = db.measurementDuration.inDays;
     _ensureWeightLostCardVisibility(nMeasured >= 2);
     Card userTargetWeightCard(double utw) => Card(
       shape: const StadiumBorder(),

--- a/app/lib/widget/statsWidgets.dart
+++ b/app/lib/widget/statsWidgets.dart
@@ -214,18 +214,6 @@ class _AnimatedStatsWidgetsState extends State<AnimatedStatsWidgets> {
 // BentoCard-based widget builders
 // ---------------------------------------------------------------------------
 
-/// Brightness-aware primary background color.
-Color _primaryBg(BuildContext context) =>
-    Theme.of(context).brightness == Brightness.light
-    ? Theme.of(context).primaryColor
-    : Theme.of(context).colorScheme.primaryContainer;
-
-/// Brightness-aware primary foreground color.
-Color _primaryFg(BuildContext context) =>
-    Theme.of(context).brightness == Brightness.light
-    ? Theme.of(context).colorScheme.onPrimary
-    : Theme.of(context).colorScheme.onPrimaryContainer;
-
 /// Full-width change-rates card (week / month / year columns).
 BentoCard changeRatesCard({
   required BuildContext context,
@@ -400,15 +388,15 @@ BentoCard reachingTargetWeightCard({
       ? l10n.targetWeightReached
       : '${labels[1]} ${l10n.targetWeightReachedIn}';
 
-  return BentoCard.hero(
-    span: 6,
+  return BentoCard.textInline(
+    columnSpan: 8,
+    rowSpan: 3,
     label: subtext,
     value: labels[0],
-    textColor: _primaryFg(context),
-    backgroundColor: _primaryBg(context),
+    reversed: true,
+    textColor: Theme.of(context).colorScheme.onPrimaryContainer,
+    backgroundColor: Theme.of(context).colorScheme.primaryContainer,
     delayInMilliseconds: delayInMilliseconds,
-    m3eShape: Shapes.sunny,
-    rotateDuration: const Duration(seconds: 60),
   );
 }
 
@@ -426,7 +414,6 @@ BentoCard nMeasurementsCard({
     label: '# $measurementsLabel',
     value: '${stats.globalNMeasurements}',
     delayInMilliseconds: delayInMilliseconds,
-    pillShape: true,
   );
 }
 
@@ -441,12 +428,12 @@ BentoCard totalChangeCard({
     listen: false,
   ).unit.name;
   return BentoCard.hero(
-    span: 6,
+    span: 4,
     label: '${AppLocalizations.of(context)!.totalChange}\n($unit)',
     value: weightToString(context, stats.deltaWeight),
     valueFlex: 3,
-    textColor: Theme.of(context).colorScheme.onTertiaryContainer,
-    backgroundColor: Theme.of(context).colorScheme.tertiaryContainer,
+    textColor: Theme.of(context).colorScheme.onSecondaryContainer,
+    backgroundColor: Theme.of(context).colorScheme.secondaryContainer,
     delayInMilliseconds: delayInMilliseconds,
   );
 }
@@ -461,12 +448,14 @@ BentoCard timeSinceFirstCard({
   final List<String> parts = durationStr.split(' ');
   final String number = parts[0];
   final String unit = parts.length > 1 ? parts.sublist(1).join(' ') : '';
-  return BentoCard.text(
-    columnSpan: 6,
+  return BentoCard.hero(
+    span: 4,
     value: number,
     label:
         '${AppLocalizations.of(context)!.timeSinceFirstMeasurement}\n($unit)',
     delayInMilliseconds: delayInMilliseconds,
+    textColor: Theme.of(context).colorScheme.onTertiaryContainer,
+    backgroundColor: Theme.of(context).colorScheme.tertiaryContainer,
   );
 }
 
@@ -484,52 +473,17 @@ BentoCard globalMaxWeightDateCard({
       notifier.statsUseInterpolation
       ? stats.globalMaxInterpolatedWeightDate
       : stats.globalMaxWeightDate;
-  final String weightStr = weightToString(context, record.weight);
   final String dateStr = record.date != null
       ? notifier.dateFormat(context).format(record.date!)
       : '--';
-  final String unit = notifier.unit.name;
   final AppLocalizations l10n = AppLocalizations.of(context)!;
-  return BentoCard(
-    columnSpan: 4,
-    rowSpan: 3,
+  return BentoCard.textInline(
+    columnSpan: 8,
+    rowSpan: 2,
+    label: '${l10n.max} (${notifier.unit.name})\n$dateStr',
+    value: weightToString(context, record.weight),
     delayInMilliseconds: delayInMilliseconds,
-    child: Padding(
-      padding: EdgeInsets.all(TraleTheme.of(context)!.padding / 2),
-      child: Column(
-        mainAxisAlignment: MainAxisAlignment.center,
-        children: <Widget>[
-          AutoSizeText(
-            '${l10n.max} ($unit)',
-            style: Theme.of(context).textTheme.bodyLarge!.onSurface(context),
-            maxLines: 2,
-            textAlign: TextAlign.center,
-          ),
-          Expanded(
-            child: Align(
-              alignment: Alignment.center,
-              child: AutoSizeText(
-                weightStr,
-                style: Theme.of(context).textTheme.emphasized.bodyMedium!
-                    .onSurface(context)
-                    .copyWith(
-                      fontWeight: FontWeight.w700,
-                      fontSize: 200,
-                      height: 0.7,
-                    ),
-                maxLines: 1,
-              ),
-            ),
-          ),
-          AutoSizeText(
-            dateStr,
-            style: Theme.of(context).textTheme.bodySmall!.onSurface(context),
-            maxLines: 1,
-            textAlign: TextAlign.center,
-          ),
-        ],
-      ),
-    ),
+    reversed: true,
   );
 }
 
@@ -547,56 +501,20 @@ BentoCard globalMinWeightDateCard({
       notifier.statsUseInterpolation
       ? stats.globalMinInterpolatedWeightDate
       : stats.globalMinWeightDate;
-  final String weightStr = weightToString(context, record.weight);
   final String dateStr = record.date != null
       ? notifier.dateFormat(context).format(record.date!)
       : '--';
-  final String unit = notifier.unit.name;
   final AppLocalizations l10n = AppLocalizations.of(context)!;
-  return BentoCard(
-    columnSpan: 4,
-    rowSpan: 3,
+  return BentoCard.textInline(
+    columnSpan: 8,
+    rowSpan: 2,
+    label: '${l10n.min} (${notifier.unit.name})\n$dateStr',
+    value: weightToString(context, record.weight),
     delayInMilliseconds: delayInMilliseconds,
-    child: Padding(
-      padding: EdgeInsets.all(TraleTheme.of(context)!.padding / 2),
-      child: Column(
-        mainAxisAlignment: MainAxisAlignment.center,
-        children: <Widget>[
-          AutoSizeText(
-            '${l10n.min} ($unit)',
-            style: Theme.of(context).textTheme.bodyLarge!.onSurface(context),
-            maxLines: 2,
-            textAlign: TextAlign.center,
-          ),
-          Expanded(
-            child: Align(
-              alignment: Alignment.center,
-              child: AutoSizeText(
-                weightStr,
-                style: Theme.of(context).textTheme.emphasized.bodyMedium!
-                    .onSurface(context)
-                    .copyWith(
-                      fontWeight: FontWeight.w700,
-                      fontSize: 200,
-                      height: 0.7,
-                    ),
-                maxLines: 1,
-              ),
-            ),
-          ),
-          AutoSizeText(
-            dateStr,
-            style: Theme.of(context).textTheme.bodySmall!.onSurface(context),
-            maxLines: 1,
-            textAlign: TextAlign.center,
-          ),
-        ],
-      ),
-    ),
   );
 }
 
-/// Text card: median weight.
+/// Emphasized card: median weight.
 BentoCard medianWeightCard({
   required BuildContext context,
   required MeasurementStats stats,
@@ -609,16 +527,17 @@ BentoCard medianWeightCard({
   final double? weight = notifier.statsUseInterpolation
       ? stats.medianInterpolatedWeight
       : stats.medianWeight;
-  return BentoCard.text(
-    columnSpan: 6,
-    rowSpan: 3,
+  return BentoCard.textInline(
+    columnSpan: 8,
+    rowSpan: 2,
     label: '${AppLocalizations.of(context)!.median} (${notifier.unit.name})',
     value: weightToString(context, weight),
+    reversed: true,
     delayInMilliseconds: delayInMilliseconds,
   );
 }
 
-/// Emphasized-text card: minimum recorded weight (label above, value below).
+/// Emphasized-text card: minimum recorded weight with date (label, value, date).
 BentoCard minWeightCard({
   required BuildContext context,
   required MeasurementStats stats,
@@ -628,32 +547,48 @@ BentoCard minWeightCard({
     context,
     listen: false,
   );
-  final double? weight = notifier.statsUseInterpolation
-      ? stats.minInterpolatedWeight
-      : stats.minWeight;
+  final ({double? weight, DateTime? date}) record =
+      notifier.statsUseInterpolation
+      ? stats.minInterpolatedWeightDate
+      : stats.minWeightDate;
+  final String dateStr = record.date != null
+      ? notifier.dateFormat(context).format(record.date!)
+      : '--';
+  final AppLocalizations l10n = AppLocalizations.of(context)!;
   return BentoCard.textEmphasized(
     columnSpan: 4,
-    rowSpan: 3,
-    label: '${AppLocalizations.of(context)!.min} (${notifier.unit.name})',
-    value: weightToString(context, weight),
-    valueFlex: 2,
+    rowSpan: 4,
+    label: '${l10n.min} (${notifier.unit.name})',
+    value: weightToString(context, record.weight),
+    sublabel: dateStr,
     delayInMilliseconds: delayInMilliseconds,
   );
 }
 
-/// Transparent card: app icon hero.
+/// Transparent card: app icon hero, placed on a given M3 shape.
 BentoCard iconHeroCard({
   required BuildContext context,
+  required Shapes shape,
+  VoidCallback? onTap,
   int delayInMilliseconds = 0,
-}) => BentoCard(
-  columnSpan: 4,
-  rowSpan: 3,
-  backgroundColor: Colors.transparent,
-  delayInMilliseconds: delayInMilliseconds,
-  child: const IconHeroStatScreen(),
-);
+}) {
+  return BentoCard.shaped(
+    span: 4,
+    backgroundColor: Theme.of(context).colorScheme.tertiaryContainer,
+    delayInMilliseconds: delayInMilliseconds,
+    m3eShape: shape,
+    rotateDuration: const Duration(seconds: 60),
+    onTap: onTap,
+    child: LayoutBuilder(
+      builder: (BuildContext context, BoxConstraints constraints) => Padding(
+        padding: EdgeInsets.only(bottom: constraints.maxHeight * 0.1),
+        child: const IconHeroStatScreen(),
+      ),
+    ),
+  );
+}
 
-/// Emphasized-text card: maximum recorded weight (value above, label below).
+/// Emphasized-text card: maximum recorded weight with date (value, label, date).
 BentoCard maxWeightCard({
   required BuildContext context,
   required MeasurementStats stats,
@@ -663,21 +598,25 @@ BentoCard maxWeightCard({
     context,
     listen: false,
   );
-  final double? weight = notifier.statsUseInterpolation
-      ? stats.maxInterpolatedWeight
-      : stats.maxWeight;
+  final ({double? weight, DateTime? date}) record =
+      notifier.statsUseInterpolation
+      ? stats.maxInterpolatedWeightDate
+      : stats.maxWeightDate;
+  final String dateStr = record.date != null
+      ? notifier.dateFormat(context).format(record.date!)
+      : '--';
+  final AppLocalizations l10n = AppLocalizations.of(context)!;
   return BentoCard.textEmphasized(
     columnSpan: 4,
-    rowSpan: 3,
-    reversed: true,
-    label: '${AppLocalizations.of(context)!.max} (${notifier.unit.name})',
-    value: weightToString(context, weight),
-    valueFlex: 2,
+    rowSpan: 4,
+    label: '${l10n.max} (${notifier.unit.name})',
+    value: weightToString(context, record.weight),
+    sublabel: dateStr,
     delayInMilliseconds: delayInMilliseconds,
   );
 }
 
-/// Text card: mean weight.
+/// Emphasized card: mean weight.
 BentoCard meanWeightCard({
   required BuildContext context,
   required MeasurementStats stats,
@@ -690,9 +629,9 @@ BentoCard meanWeightCard({
   final double? weight = notifier.statsUseInterpolation
       ? stats.meanInterpolatedWeight
       : stats.meanWeight;
-  return BentoCard.text(
-    columnSpan: 6,
-    rowSpan: 3,
+  return BentoCard.textInline(
+    columnSpan: 8,
+    rowSpan: 2,
     label: '${AppLocalizations.of(context)!.mean} (${notifier.unit.name})',
     value: weightToString(context, weight),
     delayInMilliseconds: delayInMilliseconds,
@@ -725,8 +664,8 @@ BentoCard currentStreakCard({
       context,
       addLabel: false,
     ),
-    textColor: _primaryFg(context),
-    backgroundColor: _primaryBg(context),
+    textColor: Theme.of(context).colorScheme.onPrimaryContainer,
+    backgroundColor: Theme.of(context).colorScheme.primaryContainer,
     delayInMilliseconds: delayInMilliseconds,
     m3eShape: Shapes.c12_sided_cookie,
     rotateDuration: const Duration(seconds: 60),
@@ -844,9 +783,9 @@ BentoCard calorieDeficitCard({
   required BuildContext context,
   required MeasurementStats stats,
   int delayInMilliseconds = 0,
-}) => BentoCard.text(
-  columnSpan: 6,
-  rowSpan: 3,
+}) => BentoCard.textInline(
+  columnSpan: 8,
+  rowSpan: 2,
   label: '${AppLocalizations.of(context)!.calorieDeficit}\n(kcal/day)',
   value: '${stats.dailyDeficit}',
   delayInMilliseconds: delayInMilliseconds,
@@ -862,11 +801,11 @@ BentoCard diffFromTargetCard({
     context,
     listen: false,
   ).unit.name;
-  return BentoCard.hero(
-    span: 6,
+  return BentoCard.textEmphasized(
+    columnSpan: 4,
+    rowSpan: 5,
     label: '${AppLocalizations.of(context)!.diffFromTarget} ($unit)',
     value: weightToString(context, stats.currentDifference),
-    valueFlex: 3,
     textColor: Theme.of(context).colorScheme.onTertiaryContainer,
     backgroundColor: Theme.of(context).colorScheme.tertiaryContainer,
     delayInMilliseconds: delayInMilliseconds,

--- a/app/lib/widget/statsWidgets.dart
+++ b/app/lib/widget/statsWidgets.dart
@@ -239,7 +239,7 @@ BentoCard changeRatesCard({
   final AppLocalizations l10n = AppLocalizations.of(context)!;
   return BentoCard(
     columnSpan: 12,
-    rowSpan: 3,
+    rowSpan: 2,
     delayInMilliseconds: delayInMilliseconds,
     child: Row(
       mainAxisAlignment: MainAxisAlignment.center,
@@ -289,6 +289,82 @@ BentoCard changeRatesCard({
             alignment: Alignment.centerLeft,
             child: AutoSizeText(
               '/ ${l10n.year}\n${weightToString(context, stats.deltaWeightLastYear)}',
+              style: Theme.of(
+                context,
+              ).textTheme.bodyMedium!.onSurface(context).copyWith(height: 1.0),
+              maxLines: 2,
+              textAlign: TextAlign.center,
+            ),
+          ),
+        ),
+      ],
+    ),
+  );
+}
+
+/// Full-width weight forecast card (today / +1 week / +1 month).
+BentoCard weightForecastCard({
+  required BuildContext context,
+  required MeasurementStats stats,
+  int delayInMilliseconds = 0,
+}) {
+  final String unit = Provider.of<TraleNotifier>(
+    context,
+    listen: false,
+  ).unit.name;
+  final AppLocalizations l10n = AppLocalizations.of(context)!;
+  return BentoCard(
+    columnSpan: 12,
+    rowSpan: 2,
+    delayInMilliseconds: delayInMilliseconds,
+    child: Row(
+      mainAxisAlignment: MainAxisAlignment.center,
+      children: <Widget>[
+        Expanded(
+          flex: 2,
+          child: Align(
+            alignment: Alignment.center,
+            child: AutoSizeText(
+              '${l10n.weightForecast} ($unit)',
+              style: Theme.of(context).textTheme.emphasized.bodyLarge!
+                  .onSurface(context)
+                  .copyWith(fontWeight: FontWeight.w900),
+              maxLines: 2,
+              textAlign: TextAlign.center,
+            ),
+          ),
+        ),
+        Expanded(
+          child: Align(
+            alignment: Alignment.centerLeft,
+            child: AutoSizeText(
+              '/ ${l10n.today}\n${weightToString(context, stats.weightToday)}',
+              style: Theme.of(
+                context,
+              ).textTheme.bodyMedium!.onSurface(context).copyWith(height: 1.0),
+              maxLines: 2,
+              textAlign: TextAlign.center,
+            ),
+          ),
+        ),
+        Expanded(
+          child: Align(
+            alignment: Alignment.centerLeft,
+            child: AutoSizeText(
+              '/ ${l10n.week}\n${weightToString(context, stats.weightInOneWeek)}',
+              style: Theme.of(
+                context,
+              ).textTheme.bodyMedium!.onSurface(context).copyWith(height: 1.0),
+              maxLines: 2,
+              textAlign: TextAlign.center,
+            ),
+          ),
+        ),
+        Expanded(
+          child: Align(
+            alignment: Alignment.centerLeft,
+            child: AutoSizeText(
+              '/ ${l10n.month}\n${weightToString(context, stats.weightInOneMonth)}',
               style: Theme.of(
                 context,
               ).textTheme.bodyMedium!.onSurface(context).copyWith(height: 1.0),
@@ -386,11 +462,11 @@ BentoCard timeSinceFirstCard({
   final String number = parts[0];
   final String unit = parts.length > 1 ? parts.sublist(1).join(' ') : '';
   return BentoCard.textInline(
-    columnSpan: 12,
+    columnSpan: 8,
     reversed: true,
     value: number,
     label: '$unit\n${AppLocalizations.of(context)!.timeSinceFirstMeasurement}',
-    valueFlex: 2,
+    valueFlex: 1,
     delayInMilliseconds: delayInMilliseconds,
   );
 }
@@ -406,8 +482,8 @@ BentoCard minWeightCard({
     listen: false,
   ).unit.name;
   return BentoCard.textEmphasized(
-    columnSpan: 5,
-    rowSpan: 2,
+    columnSpan: 4,
+    rowSpan: 3,
     label: '${AppLocalizations.of(context)!.min} ($unit)',
     value: weightToString(context, stats.minWeight),
     valueFlex: 2,
@@ -420,8 +496,8 @@ BentoCard iconHeroCard({
   required BuildContext context,
   int delayInMilliseconds = 0,
 }) => BentoCard(
-  columnSpan: 2,
-  rowSpan: 2,
+  columnSpan: 4,
+  rowSpan: 3,
   backgroundColor: Colors.transparent,
   delayInMilliseconds: delayInMilliseconds,
   child: const IconHeroStatScreen(),
@@ -438,8 +514,8 @@ BentoCard maxWeightCard({
     listen: false,
   ).unit.name;
   return BentoCard.textEmphasized(
-    columnSpan: 5,
-    rowSpan: 2,
+    columnSpan: 4,
+    rowSpan: 3,
     reversed: true,
     label: '${AppLocalizations.of(context)!.max} ($unit)',
     value: weightToString(context, stats.maxWeight),
@@ -552,13 +628,13 @@ BentoCard diffFromTargetCard({
   return BentoCard.hero(
     span: 6,
     label: '${AppLocalizations.of(context)!.diffFromTarget} ($unit)',
-    value: weightToString(context, stats.currentDifference),
+    value: '2', //weightToString(context, stats.currentDifference),
     valueFlex: 3,
     textColor: Theme.of(context).colorScheme.onTertiaryContainer,
     backgroundColor: Theme.of(context).colorScheme.tertiaryContainer,
     delayInMilliseconds: delayInMilliseconds,
-    m3eShape: Shapes.pill,
-    rotateDuration: const Duration(seconds: 120),
+    m3eShape: Shapes.l8_leaf_clover,
+    rotateDuration: const Duration(seconds: 40),
   );
 }
 

--- a/app/lib/widget/statsWidgets.dart
+++ b/app/lib/widget/statsWidgets.dart
@@ -308,7 +308,7 @@ StatCard getCurrentStreak({
             child: Align(
               alignment: Alignment.center,
               child: AutoSizeText(
-                stats.currentStreak.streakToStringDays(
+                stats.globalCurrentStreak.streakToStringDays(
                   context,
                   addLabel: false,
                 ),

--- a/app/lib/widget/statsWidgetsList.dart
+++ b/app/lib/widget/statsWidgetsList.dart
@@ -1,5 +1,8 @@
 // ignore_for_file: file_names
+import 'dart:math';
+
 import 'package:flutter/material.dart';
+import 'package:flutter_m3shapes_extended/flutter_m3shapes_extended.dart';
 import 'package:provider/provider.dart';
 import 'package:trale/core/measurementStats.dart';
 import 'package:trale/core/theme.dart';
@@ -8,10 +11,39 @@ import 'package:trale/widget/bento_card.dart';
 import 'package:trale/widget/bento_grid.dart';
 import 'package:trale/widget/statsWidgets.dart';
 
+/// Shapes used for the trale icon card — cycled on tap.
+const List<Shapes> _iconHeroShapes = <Shapes>[
+  Shapes.sunny,
+  Shapes.c4_sided_cookie,
+  Shapes.c6_sided_cookie,
+  Shapes.c7_sided_cookie,
+  Shapes.c9_sided_cookie,
+  Shapes.c12_sided_cookie,
+  Shapes.l4_leaf_clover,
+  Shapes.gem,
+];
+
 /// Range-based statistics widgets laid out as a bento grid.
-class StatsWidgetsList extends StatelessWidget {
+class StatsWidgetsList extends StatefulWidget {
   /// Constructor.
   const StatsWidgetsList({super.key});
+
+  @override
+  State<StatsWidgetsList> createState() => _StatsWidgetsListState();
+}
+
+class _StatsWidgetsListState extends State<StatsWidgetsList> {
+  Shapes _iconShape = _iconHeroShapes[Random().nextInt(_iconHeroShapes.length)];
+
+  void _cycleIconShape() {
+    setState(() {
+      Shapes next;
+      do {
+        next = _iconHeroShapes[Random().nextInt(_iconHeroShapes.length)];
+      } while (next == _iconShape);
+      _iconShape = next;
+    });
+  }
 
   @override
   Widget build(BuildContext context) {
@@ -33,7 +65,26 @@ class StatsWidgetsList extends StatelessWidget {
             changeRatesCard(context: context, stats: stats),
             diffFromTargetCard(context: context, stats: stats),
             calorieDeficitCard(context: context, stats: stats),
+            reachingTargetWeightCard(context: context, stats: stats),
+            weightForecastCard(context: context, stats: stats),
+            minWeightCard(context: context, stats: stats),
+            iconHeroCard(
+              context: context,
+              shape: _iconShape,
+              onTap: _cycleIconShape,
+              delayInMilliseconds: (delay / 2).toInt(),
+            ),
+            maxWeightCard(
+              context: context,
+              stats: stats,
+              delayInMilliseconds: delay,
+            ),
             meanWeightCard(
+              context: context,
+              stats: stats,
+              delayInMilliseconds: delay,
+            ),
+            totalChangeCard(
               context: context,
               stats: stats,
               delayInMilliseconds: delay,
@@ -43,26 +94,7 @@ class StatsWidgetsList extends StatelessWidget {
               stats: stats,
               delayInMilliseconds: delay,
             ),
-            minWeightCard(context: context, stats: stats),
-            iconHeroCard(
-              context: context,
-              delayInMilliseconds: (delay / 2).toInt(),
-            ),
-            maxWeightCard(
-              context: context,
-              stats: stats,
-              delayInMilliseconds: delay,
-            ),
-            reachingTargetWeightCard(context: context, stats: stats),
-            totalChangeCard(
-              context: context,
-              stats: stats,
-              delayInMilliseconds: delay,
-            ),
-            weightForecastCard(context: context, stats: stats),
-
-            if (notifier.userHeight != null)
-              bmiCard(context: context, stats: stats),
+            bmiCard(context: context, stats: stats),
           ],
         ),
         SizedBox(height: padding),
@@ -100,6 +132,7 @@ class GlobalStatsWidgetsList extends StatelessWidget {
           ),
           maxStreakCard(context: context, stats: stats),
           measurementFrequencyCard(context: context, stats: stats),
+          timeSinceFirstCard(context: context, stats: stats),
           globalMaxWeightDateCard(
             context: context,
             stats: stats,
@@ -110,7 +143,6 @@ class GlobalStatsWidgetsList extends StatelessWidget {
             stats: stats,
             delayInMilliseconds: delay,
           ),
-          timeSinceFirstCard(context: context, stats: stats),
         ],
       ),
     );

--- a/app/lib/widget/statsWidgetsList.dart
+++ b/app/lib/widget/statsWidgetsList.dart
@@ -59,21 +59,23 @@ class _StatsWidgetsListState extends State<StatsWidgetsList> {
       children:
           <Widget>[
             Column(
+              spacing: TraleTheme.of(context)!.padding,
               children: <Widget>[
                 DefaultStatCard(
-                  firstRow: AppLocalizations.of(context)!.currentStreak,
-                  secondRow: stats.currentStreak.durationToStringDays(context),
-                ),
-                SizedBox(height: TraleTheme.of(context)!.padding),
-                DefaultStatCard(
                   firstRow: AppLocalizations.of(context)!.maxStreak,
-                  secondRow: stats.maxStreak.durationToStringDays(context),
+                  secondRow: stats.maxStreak.streakToStringDays(context),
+                ),
+                DefaultStatCard(
+                  firstRow:
+                      '${AppLocalizations.of(context)!.measurementFrequency}\n'
+                      '(/ ${AppLocalizations.of(context)!.week})',
+                  secondRow: stats.frequency!.toStringAsFixed(2),
                 ),
               ],
             ),
             Column(
               children: <Widget>[
-                getFrequencyInTotal(
+                getCurrentStreak(
                   context: context,
                   stats: stats,
                   delayInMilliseconds: delayInMilliseconds,

--- a/app/lib/widget/statsWidgetsList.dart
+++ b/app/lib/widget/statsWidgetsList.dart
@@ -1,6 +1,5 @@
 // ignore_for_file: file_names
 import 'package:flutter/material.dart';
-import 'package:flutter_m3shapes_extended/flutter_m3shapes_extended.dart';
 import 'package:provider/provider.dart';
 import 'package:trale/core/measurementStats.dart';
 import 'package:trale/core/theme.dart';
@@ -35,6 +34,11 @@ class StatsWidgetsList extends StatelessWidget {
             diffFromTargetCard(context: context, stats: stats),
             calorieDeficitCard(context: context, stats: stats),
             meanWeightCard(
+              context: context,
+              stats: stats,
+              delayInMilliseconds: delay,
+            ),
+            medianWeightCard(
               context: context,
               stats: stats,
               delayInMilliseconds: delay,
@@ -96,21 +100,17 @@ class GlobalStatsWidgetsList extends StatelessWidget {
           ),
           maxStreakCard(context: context, stats: stats),
           measurementFrequencyCard(context: context, stats: stats),
-          BentoCard.shaped(
-            span: 2,
-            m3eShape: Shapes.soft_boom,
-            backgroundColor: Theme.of(context).colorScheme.tertiaryContainer,
-            rotateDuration: Duration(seconds: 15),
-            child: const SizedBox.shrink(),
+          globalMaxWeightDateCard(
+            context: context,
+            stats: stats,
+            delayInMilliseconds: delay,
+          ),
+          globalMinWeightDateCard(
+            context: context,
+            stats: stats,
+            delayInMilliseconds: delay,
           ),
           timeSinceFirstCard(context: context, stats: stats),
-          BentoCard.shaped(
-            span: 2,
-            m3eShape: Shapes.soft_boom,
-            backgroundColor: Theme.of(context).colorScheme.tertiaryContainer,
-            rotateDuration: Duration(seconds: 15),
-            child: const SizedBox.shrink(),
-          ),
         ],
       ),
     );

--- a/app/lib/widget/statsWidgetsList.dart
+++ b/app/lib/widget/statsWidgetsList.dart
@@ -1,10 +1,10 @@
 // ignore_for_file: file_names
 import 'package:flutter/material.dart';
+import 'package:flutter_m3shapes_extended/flutter_m3shapes_extended.dart';
 import 'package:provider/provider.dart';
 import 'package:trale/core/measurementStats.dart';
 import 'package:trale/core/theme.dart';
 import 'package:trale/core/traleNotifier.dart';
-import 'package:trale/l10n-gen/app_localizations.dart';
 import 'package:trale/widget/bento_card.dart';
 import 'package:trale/widget/bento_grid.dart';
 import 'package:trale/widget/statsWidgets.dart';
@@ -32,8 +32,9 @@ class StatsWidgetsList extends StatelessWidget {
         BentoGrid(
           children: <BentoCard>[
             changeRatesCard(context: context, stats: stats),
-            reachingTargetWeightCard(context: context, stats: stats),
-            totalChangeCard(
+            diffFromTargetCard(context: context, stats: stats),
+            calorieDeficitCard(context: context, stats: stats),
+            meanWeightCard(
               context: context,
               stats: stats,
               delayInMilliseconds: delay,
@@ -48,13 +49,14 @@ class StatsWidgetsList extends StatelessWidget {
               stats: stats,
               delayInMilliseconds: delay,
             ),
-            diffFromTargetCard(context: context, stats: stats),
-            meanWeightCard(
+            reachingTargetWeightCard(context: context, stats: stats),
+            totalChangeCard(
               context: context,
               stats: stats,
               delayInMilliseconds: delay,
             ),
-            calorieDeficitCard(context: context, stats: stats),
+            weightForecastCard(context: context, stats: stats),
+
             if (notifier.userHeight != null)
               bmiCard(context: context, stats: stats),
           ],
@@ -78,36 +80,39 @@ class GlobalStatsWidgetsList extends StatelessWidget {
     )!.transitionDuration.normal.inMilliseconds;
     final double padding = TraleTheme.of(context)!.padding;
 
-    return Column(
-      crossAxisAlignment: CrossAxisAlignment.start,
-      children: <Widget>[
-        Padding(
-          padding: EdgeInsets.symmetric(horizontal: padding),
-          child: Text(
-            AppLocalizations.of(context)!.all,
-            style: Theme.of(context).textTheme.titleMedium,
+    return Padding(
+      padding: EdgeInsets.only(bottom: padding),
+      child: BentoGrid(
+        children: <BentoCard>[
+          nMeasurementsCard(
+            context: context,
+            stats: stats,
+            delayInMilliseconds: delay,
           ),
-        ),
-        SizedBox(height: padding / 2),
-        BentoGrid(
-          children: <BentoCard>[
-            nMeasurementsCard(
-              context: context,
-              stats: stats,
-              delayInMilliseconds: delay,
-            ),
-            currentStreakCard(
-              context: context,
-              stats: stats,
-              delayInMilliseconds: delay,
-            ),
-            maxStreakCard(context: context, stats: stats),
-            measurementFrequencyCard(context: context, stats: stats),
-            timeSinceFirstCard(context: context, stats: stats),
-          ],
-        ),
-        SizedBox(height: padding),
-      ],
+          currentStreakCard(
+            context: context,
+            stats: stats,
+            delayInMilliseconds: delay,
+          ),
+          maxStreakCard(context: context, stats: stats),
+          measurementFrequencyCard(context: context, stats: stats),
+          BentoCard.shaped(
+            span: 2,
+            m3eShape: Shapes.soft_boom,
+            backgroundColor: Theme.of(context).colorScheme.tertiaryContainer,
+            rotateDuration: Duration(seconds: 15),
+            child: const SizedBox.shrink(),
+          ),
+          timeSinceFirstCard(context: context, stats: stats),
+          BentoCard.shaped(
+            span: 2,
+            m3eShape: Shapes.soft_boom,
+            backgroundColor: Theme.of(context).colorScheme.tertiaryContainer,
+            rotateDuration: Duration(seconds: 15),
+            child: const SizedBox.shrink(),
+          ),
+        ],
+      ),
     );
   }
 }

--- a/app/lib/widget/statsWidgetsList.dart
+++ b/app/lib/widget/statsWidgetsList.dart
@@ -1,147 +1,112 @@
 // ignore_for_file: file_names
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
-import 'package:trale/core/durationExtension.dart';
 import 'package:trale/core/measurementStats.dart';
 import 'package:trale/core/theme.dart';
 import 'package:trale/core/traleNotifier.dart';
 import 'package:trale/l10n-gen/app_localizations.dart';
-import 'package:trale/widget/statsCards.dart';
+import 'package:trale/widget/bento_card.dart';
+import 'package:trale/widget/bento_grid.dart';
 import 'package:trale/widget/statsWidgets.dart';
 
-/// List of statistics widgets.
-class StatsWidgetsList extends StatefulWidget {
+/// Range-based statistics widgets laid out as a bento grid.
+class StatsWidgetsList extends StatelessWidget {
   /// Constructor.
   const StatsWidgetsList({super.key});
 
   @override
-  State<StatsWidgetsList> createState() => _StatsWidgetsListState();
-}
-
-class _StatsWidgetsListState extends State<StatsWidgetsList> {
-  @override
   Widget build(BuildContext context) {
     final MeasurementStats stats = MeasurementStats();
-
-    final int delayInMilliseconds = TraleTheme.of(
-      context,
-    )!.transitionDuration.normal.inMilliseconds;
-
     final TraleNotifier notifier = Provider.of<TraleNotifier>(
       context,
       listen: false,
     );
-
-    final Widget minMaxWidget = Row(
-      mainAxisAlignment: MainAxisAlignment.center,
-      spacing: TraleTheme.of(context)!.padding,
-      children: <Widget>[
-        getMinWidget(context: context, stats: stats),
-        getIconWidget(
-          context: context,
-          stats: stats,
-          delayInMilliseconds: (delayInMilliseconds / 2).toInt(),
-        ),
-        getMaxWidget(
-          context: context,
-          stats: stats,
-          delayInMilliseconds: delayInMilliseconds,
-        ),
-      ],
-    );
-
-    final Widget streakAndFrequencyWidget = Row(
-      mainAxisAlignment: MainAxisAlignment.center,
-      spacing: TraleTheme.of(context)!.padding,
-      children: <Widget>[
-        Column(
-          spacing: TraleTheme.of(context)!.padding,
-          children: <Widget>[
-            DefaultStatCard(
-              firstRow: AppLocalizations.of(context)!.maxStreak,
-              secondRow: stats.globalMaxStreak.streakToStringDays(context),
-            ),
-            DefaultStatCard(
-              firstRow:
-                  '${AppLocalizations.of(context)!.measurementFrequency}\n'
-                  '(/ ${AppLocalizations.of(context)!.week})',
-              secondRow: stats.globalFrequency!.toStringAsFixed(2),
-            ),
-          ],
-        ),
-        Column(
-          spacing: TraleTheme.of(context)!.padding,
-          children: <Widget>[
-            getCurrentStreak(
-              context: context,
-              stats: stats,
-              delayInMilliseconds: delayInMilliseconds,
-            ),
-          ],
-        ),
-      ],
-    );
-
-    final String measurementsLabel = AppLocalizations.of(
+    final int delay = TraleTheme.of(
       context,
-    )!.measurements.toLowerCase();
-
-    final Widget col234 = Row(
-      mainAxisAlignment: MainAxisAlignment.center,
-      spacing: TraleTheme.of(context)!.padding,
-      children: <Widget>[
-        Column(
-          spacing: TraleTheme.of(context)!.padding,
-          children: <Widget>[
-            getReachingTargetWeightWidget(context: context, stats: stats),
-            DefaultStatCard(
-              firstRow: AppLocalizations.of(context)!.timeSinceFirstMeasurement,
-              secondRow: stats.globalDeltaTime.durationToString(context),
-            ),
-          ],
-        ),
-        Column(
-          spacing: TraleTheme.of(context)!.padding,
-          children: <Widget>[
-            DefaultStatCard(
-              firstRow: '# $measurementsLabel',
-              secondRow: '${stats.globalNMeasurements}',
-              delayInMilliseconds: delayInMilliseconds,
-              pillShape: true,
-            ),
-            getTotalChangeWidget(
-              context: context,
-              stats: stats,
-              delayInMilliseconds: delayInMilliseconds,
-            ),
-          ],
-        ),
-      ],
-    );
-
-    final Widget unsortedStatsWidget = Row(
-      mainAxisAlignment: MainAxisAlignment.center,
-      spacing: TraleTheme.of(context)!.padding,
-      children: <Widget>[
-        getCalorieDeficitWidget(context: context, stats: stats),
-        getDiffFromTargetWidget(context: context, stats: stats),
-      ],
-    );
+    )!.transitionDuration.normal.inMilliseconds;
+    final double padding = TraleTheme.of(context)!.padding;
 
     return Column(
-      crossAxisAlignment: CrossAxisAlignment.center,
-      spacing: TraleTheme.of(context)!.padding,
       children: <Widget>[
-        SizedBox(height: TraleTheme.of(context)!.padding),
-        getChangeRatesWidget(context: context, stats: stats),
-        col234,
-        minMaxWidget,
-        getMeanWidget(context: context, stats: stats),
-        streakAndFrequencyWidget,
-        if (notifier.userHeight != null)
-          getBMIWidget(context: context, stats: stats),
-        unsortedStatsWidget,
-        SizedBox(height: TraleTheme.of(context)!.padding),
+        SizedBox(height: padding),
+        BentoGrid(
+          children: <BentoCard>[
+            changeRatesCard(context: context, stats: stats),
+            reachingTargetWeightCard(context: context, stats: stats),
+            totalChangeCard(
+              context: context,
+              stats: stats,
+              delayInMilliseconds: delay,
+            ),
+            minWeightCard(context: context, stats: stats),
+            iconHeroCard(
+              context: context,
+              delayInMilliseconds: (delay / 2).toInt(),
+            ),
+            maxWeightCard(
+              context: context,
+              stats: stats,
+              delayInMilliseconds: delay,
+            ),
+            diffFromTargetCard(context: context, stats: stats),
+            meanWeightCard(
+              context: context,
+              stats: stats,
+              delayInMilliseconds: delay,
+            ),
+            calorieDeficitCard(context: context, stats: stats),
+            if (notifier.userHeight != null)
+              bmiCard(context: context, stats: stats),
+          ],
+        ),
+        SizedBox(height: padding),
+      ],
+    );
+  }
+}
+
+/// All-time (global) statistics widgets with a section heading.
+class GlobalStatsWidgetsList extends StatelessWidget {
+  /// Constructor.
+  const GlobalStatsWidgetsList({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    final MeasurementStats stats = MeasurementStats();
+    final int delay = TraleTheme.of(
+      context,
+    )!.transitionDuration.normal.inMilliseconds;
+    final double padding = TraleTheme.of(context)!.padding;
+
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: <Widget>[
+        Padding(
+          padding: EdgeInsets.symmetric(horizontal: padding),
+          child: Text(
+            AppLocalizations.of(context)!.all,
+            style: Theme.of(context).textTheme.titleMedium,
+          ),
+        ),
+        SizedBox(height: padding / 2),
+        BentoGrid(
+          children: <BentoCard>[
+            nMeasurementsCard(
+              context: context,
+              stats: stats,
+              delayInMilliseconds: delay,
+            ),
+            currentStreakCard(
+              context: context,
+              stats: stats,
+              delayInMilliseconds: delay,
+            ),
+            maxStreakCard(context: context, stats: stats),
+            measurementFrequencyCard(context: context, stats: stats),
+            timeSinceFirstCard(context: context, stats: stats),
+          ],
+        ),
+        SizedBox(height: padding),
       ],
     );
   }

--- a/app/lib/widget/statsWidgetsList.dart
+++ b/app/lib/widget/statsWidgetsList.dart
@@ -2,7 +2,6 @@
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 import 'package:trale/core/durationExtension.dart';
-import 'package:trale/core/gap.dart';
 import 'package:trale/core/measurementStats.dart';
 import 'package:trale/core/theme.dart';
 import 'package:trale/core/traleNotifier.dart';
@@ -34,58 +33,53 @@ class _StatsWidgetsListState extends State<StatsWidgetsList> {
     );
 
     final Widget minMaxWidget = Row(
-      mainAxisAlignment: MainAxisAlignment.spaceBetween,
-      children:
-          <Widget>[
-            getMinWidget(context: context, stats: stats),
-            getIconWidget(
-              context: context,
-              stats: stats,
-              delayInMilliseconds: (delayInMilliseconds / 2).toInt(),
+      mainAxisAlignment: MainAxisAlignment.center,
+      spacing: TraleTheme.of(context)!.padding,
+      children: <Widget>[
+        getMinWidget(context: context, stats: stats),
+        getIconWidget(
+          context: context,
+          stats: stats,
+          delayInMilliseconds: (delayInMilliseconds / 2).toInt(),
+        ),
+        getMaxWidget(
+          context: context,
+          stats: stats,
+          delayInMilliseconds: delayInMilliseconds,
+        ),
+      ],
+    );
+
+    final Widget streakAndFrequencyWidget = Row(
+      mainAxisAlignment: MainAxisAlignment.center,
+      spacing: TraleTheme.of(context)!.padding,
+      children: <Widget>[
+        Column(
+          spacing: TraleTheme.of(context)!.padding,
+          children: <Widget>[
+            DefaultStatCard(
+              firstRow: AppLocalizations.of(context)!.maxStreak,
+              secondRow: stats.maxStreak.streakToStringDays(context),
             ),
-            getMaxWidget(
+            DefaultStatCard(
+              firstRow:
+                  '${AppLocalizations.of(context)!.measurementFrequency}\n'
+                  '(/ ${AppLocalizations.of(context)!.week})',
+              secondRow: stats.frequency!.toStringAsFixed(2),
+            ),
+          ],
+        ),
+        Column(
+          spacing: TraleTheme.of(context)!.padding,
+          children: <Widget>[
+            getCurrentStreak(
               context: context,
               stats: stats,
               delayInMilliseconds: delayInMilliseconds,
             ),
-          ].addGap(
-            padding: TraleTheme.of(context)!.padding,
-            direction: Axis.horizontal,
-          ),
-    );
-
-    final Widget streakAndFrequencyWidget = Row(
-      mainAxisAlignment: MainAxisAlignment.start,
-      children:
-          <Widget>[
-            Column(
-              spacing: TraleTheme.of(context)!.padding,
-              children: <Widget>[
-                DefaultStatCard(
-                  firstRow: AppLocalizations.of(context)!.maxStreak,
-                  secondRow: stats.maxStreak.streakToStringDays(context),
-                ),
-                DefaultStatCard(
-                  firstRow:
-                      '${AppLocalizations.of(context)!.measurementFrequency}\n'
-                      '(/ ${AppLocalizations.of(context)!.week})',
-                  secondRow: stats.frequency!.toStringAsFixed(2),
-                ),
-              ],
-            ),
-            Column(
-              children: <Widget>[
-                getCurrentStreak(
-                  context: context,
-                  stats: stats,
-                  delayInMilliseconds: delayInMilliseconds,
-                ),
-              ],
-            ),
-          ].addGap(
-            padding: TraleTheme.of(context)!.padding,
-            direction: Axis.horizontal,
-          ),
+          ],
+        ),
+      ],
     );
 
     final String measurementsLabel = AppLocalizations.of(
@@ -93,59 +87,62 @@ class _StatsWidgetsListState extends State<StatsWidgetsList> {
     )!.measurements.toLowerCase();
 
     final Widget col234 = Row(
-      mainAxisAlignment: MainAxisAlignment.start,
-      children:
-          <Widget>[
-            Column(
-              children: <Widget>[
-                getReachingTargetWeightWidget(context: context, stats: stats),
-                SizedBox(height: TraleTheme.of(context)!.padding),
-                DefaultStatCard(
-                  firstRow: AppLocalizations.of(
-                    context,
-                  )!.timeSinceFirstMeasurement,
-                  secondRow: stats.deltaTime.durationToString(context),
-                ),
-              ],
+      mainAxisAlignment: MainAxisAlignment.center,
+      spacing: TraleTheme.of(context)!.padding,
+      children: <Widget>[
+        Column(
+          spacing: TraleTheme.of(context)!.padding,
+          children: <Widget>[
+            getReachingTargetWeightWidget(context: context, stats: stats),
+            DefaultStatCard(
+              firstRow: AppLocalizations.of(context)!.timeSinceFirstMeasurement,
+              secondRow: stats.deltaTime.durationToString(context),
             ),
-            Column(
-              children: <Widget>[
-                DefaultStatCard(
-                  firstRow: '# $measurementsLabel',
-                  secondRow: '${stats.nMeasurements}',
-                  delayInMilliseconds: delayInMilliseconds,
-                  pillShape: true,
-                ),
-                SizedBox(height: TraleTheme.of(context)!.padding),
-                getTotalChangeWidget(
-                  context: context,
-                  stats: stats,
-                  delayInMilliseconds: delayInMilliseconds,
-                ),
-              ],
+          ],
+        ),
+        Column(
+          spacing: TraleTheme.of(context)!.padding,
+          children: <Widget>[
+            DefaultStatCard(
+              firstRow: '# $measurementsLabel',
+              secondRow: '${stats.nMeasurements}',
+              delayInMilliseconds: delayInMilliseconds,
+              pillShape: true,
             ),
-          ].addGap(
-            padding: TraleTheme.of(context)!.padding,
-            direction: Axis.horizontal,
-          ),
+            getTotalChangeWidget(
+              context: context,
+              stats: stats,
+              delayInMilliseconds: delayInMilliseconds,
+            ),
+          ],
+        ),
+      ],
+    );
+
+    final Widget unsortedStatsWidget = Row(
+      mainAxisAlignment: MainAxisAlignment.center,
+      spacing: TraleTheme.of(context)!.padding,
+      children: <Widget>[
+        getCalorieDeficitWidget(context: context, stats: stats),
+        getDiffFromTargetWidget(context: context, stats: stats),
+      ],
     );
 
     return Column(
       crossAxisAlignment: CrossAxisAlignment.center,
-      children:
-          <Widget>[
-            getChangeRatesWidget(context: context, stats: stats),
-            col234,
-            minMaxWidget,
-            getMeanWidget(context: context, stats: stats),
-            streakAndFrequencyWidget,
-            if (notifier.userHeight != null)
-              getBMIWidget(context: context, stats: stats),
-            SizedBox(height: TraleTheme.of(context)!.padding),
-          ].addGap(
-            padding: TraleTheme.of(context)!.padding,
-            direction: Axis.vertical,
-          ),
+      spacing: TraleTheme.of(context)!.padding,
+      children: <Widget>[
+        SizedBox(height: TraleTheme.of(context)!.padding),
+        getChangeRatesWidget(context: context, stats: stats),
+        col234,
+        minMaxWidget,
+        getMeanWidget(context: context, stats: stats),
+        streakAndFrequencyWidget,
+        if (notifier.userHeight != null)
+          getBMIWidget(context: context, stats: stats),
+        unsortedStatsWidget,
+        SizedBox(height: TraleTheme.of(context)!.padding),
+      ],
     );
   }
 }

--- a/app/lib/widget/statsWidgetsList.dart
+++ b/app/lib/widget/statsWidgetsList.dart
@@ -59,13 +59,13 @@ class _StatsWidgetsListState extends State<StatsWidgetsList> {
           children: <Widget>[
             DefaultStatCard(
               firstRow: AppLocalizations.of(context)!.maxStreak,
-              secondRow: stats.maxStreak.streakToStringDays(context),
+              secondRow: stats.globalMaxStreak.streakToStringDays(context),
             ),
             DefaultStatCard(
               firstRow:
                   '${AppLocalizations.of(context)!.measurementFrequency}\n'
                   '(/ ${AppLocalizations.of(context)!.week})',
-              secondRow: stats.frequency!.toStringAsFixed(2),
+              secondRow: stats.globalFrequency!.toStringAsFixed(2),
             ),
           ],
         ),
@@ -96,7 +96,7 @@ class _StatsWidgetsListState extends State<StatsWidgetsList> {
             getReachingTargetWeightWidget(context: context, stats: stats),
             DefaultStatCard(
               firstRow: AppLocalizations.of(context)!.timeSinceFirstMeasurement,
-              secondRow: stats.deltaTime.durationToString(context),
+              secondRow: stats.globalDeltaTime.durationToString(context),
             ),
           ],
         ),
@@ -105,7 +105,7 @@ class _StatsWidgetsListState extends State<StatsWidgetsList> {
           children: <Widget>[
             DefaultStatCard(
               firstRow: '# $measurementsLabel',
-              secondRow: '${stats.nMeasurements}',
+              secondRow: '${stats.globalNMeasurements}',
               delayInMilliseconds: delayInMilliseconds,
               pillShape: true,
             ),

--- a/app/pubspec.lock
+++ b/app/pubspec.lock
@@ -269,10 +269,10 @@ packages:
     dependency: "direct main"
     description:
       name: file_picker
-      sha256: "57d9a1dd5063f85fa3107fb42d1faffda52fdc948cefd5fe5ea85267a5fc7343"
+      sha256: f13a03000d942e476bc1ff0a736d2e9de711d2f89a95cd4c1d88f861c3348387
       url: "https://pub.dev"
     source: hosted
-    version: "10.3.10"
+    version: "11.0.2"
   file_saver:
     dependency: "direct main"
     description:
@@ -306,10 +306,10 @@ packages:
     dependency: "direct main"
     description:
       name: flutter_auto_size_text
-      sha256: eba9a0053ab13703eca8468754940f1567cfd364b5aa7225420ea5ec3c02b83e
+      sha256: d44a1f0360a731d8734dc5482a1f60756cd927a45a1a0759e1b2b839fe832427
       url: "https://pub.dev"
     source: hosted
-    version: "4.1.0"
+    version: "5.0.0"
   flutter_keyboard_visibility_linux:
     dependency: transitive
     description:
@@ -370,34 +370,34 @@ packages:
     dependency: "direct main"
     description:
       name: flutter_local_notifications
-      sha256: "2b50e938a275e1ad77352d6a25e25770f4130baa61eaf02de7a9a884680954ad"
+      sha256: "0d9035862236fe38250fe1644d7ed3b8254e34a21b2c837c9f539fbb3bba5ef1"
       url: "https://pub.dev"
     source: hosted
-    version: "20.1.0"
+    version: "21.0.0"
   flutter_local_notifications_linux:
     dependency: transitive
     description:
       name: flutter_local_notifications_linux
-      sha256: dce0116868cedd2cdf768af0365fc37ff1cbef7c02c4f51d0587482e625868d0
+      sha256: e0f25e243c6c44c825bbbc6b2b2e76f7d9222362adcfe9fd780bf01923c840bd
       url: "https://pub.dev"
     source: hosted
-    version: "7.0.0"
+    version: "8.0.0"
   flutter_local_notifications_platform_interface:
     dependency: transitive
     description:
       name: flutter_local_notifications_platform_interface
-      sha256: "23de31678a48c084169d7ae95866df9de5c9d2a44be3e5915a2ff067aeeba899"
+      sha256: e7db3d5b49c2b7ecc68deba4aaaa67a348f92ee0fef34c8e4b4459dbef0d7307
       url: "https://pub.dev"
     source: hosted
-    version: "10.0.0"
+    version: "11.0.0"
   flutter_local_notifications_windows:
     dependency: transitive
     description:
       name: flutter_local_notifications_windows
-      sha256: e97a1a3016512437d9c0b12fae7d1491c3c7b9aa7f03a69b974308840656b02a
+      sha256: "3a2654ba104fbb52c618ebed9def24ef270228470718c43b3a6afcd5c81bef0c"
       url: "https://pub.dev"
     source: hosted
-    version: "2.0.1"
+    version: "3.0.0"
   flutter_localizations:
     dependency: "direct main"
     description: flutter
@@ -1022,10 +1022,10 @@ packages:
     dependency: "direct main"
     description:
       name: timezone
-      sha256: dd14a3b83cfd7cb19e7888f1cbc20f258b8d71b54c06f79ac585f14093a287d1
+      sha256: "784a5e34d2eb62e1326f24d6f600aaaee452eb8ca8ef2f384a59244e292d158b"
       url: "https://pub.dev"
     source: hosted
-    version: "0.10.1"
+    version: "0.11.0"
   translations_cleaner:
     dependency: "direct dev"
     description:
@@ -1228,4 +1228,4 @@ packages:
     version: "2.1.0"
 sdks:
   dart: ">=3.11.0 <4.0.0"
-  flutter: ">=3.41.0"
+  flutter: ">=3.41.6"

--- a/app/pubspec.lock
+++ b/app/pubspec.lock
@@ -403,6 +403,14 @@ packages:
     description: flutter
     source: sdk
     version: "0.0.0"
+  flutter_m3shapes_extended:
+    dependency: "direct main"
+    description:
+      name: flutter_m3shapes_extended
+      sha256: "93258d82efcc72c249f69b0fd991b535d5a2da99a5dd1aa77af07a6b4f86600f"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.1.0"
   flutter_plugin_android_lifecycle:
     dependency: transitive
     description:
@@ -593,10 +601,10 @@ packages:
     dependency: transitive
     description:
       name: matcher
-      sha256: "12956d0ad8390bbcc63ca2e1469c0619946ccb52809807067a7020d57e647aa6"
+      sha256: dc0b7dc7651697ea4ff3e69ef44b0407ea32c487a39fff6a4004fa585e901861
       url: "https://pub.dev"
     source: hosted
-    version: "0.12.18"
+    version: "0.12.19"
   material_color_utilities:
     dependency: transitive
     description:
@@ -685,6 +693,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.9.1"
+  path_drawing:
+    dependency: transitive
+    description:
+      name: path_drawing
+      sha256: bbb1934c0cbb03091af082a6389ca2080345291ef07a5fa6d6e078ba8682f977
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.0.1"
   path_parsing:
     dependency: transitive
     description:
@@ -982,10 +998,10 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: "19a78f63e83d3a61f00826d09bc2f60e191bf3504183c001262be6ac75589fb8"
+      sha256: "8161c84903fd860b26bfdefb7963b3f0b68fee7adea0f59ef805ecca346f0c7a"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.8"
+    version: "0.7.10"
   timezone:
     dependency: "direct main"
     description:
@@ -1195,5 +1211,5 @@ packages:
     source: hosted
     version: "2.1.0"
 sdks:
-  dart: ">=3.10.3 <4.0.0"
+  dart: ">=3.11.0 <4.0.0"
   flutter: ">=3.41.0"

--- a/app/pubspec.lock
+++ b/app/pubspec.lock
@@ -21,10 +21,10 @@ packages:
     dependency: transitive
     description:
       name: archive
-      sha256: "2fde1607386ab523f7a36bb3e7edb43bd58e6edaf2ffb29d8a6d578b297fdbbd"
+      sha256: a96e8b390886ee8abb49b7bd3ac8df6f451c621619f52a26e815fdcf568959ff
       url: "https://pub.dev"
     source: hosted
-    version: "4.0.7"
+    version: "4.0.9"
   args:
     dependency: transitive
     description:
@@ -37,10 +37,10 @@ packages:
     dependency: transitive
     description:
       name: async
-      sha256: "758e6d74e971c3e5aceb4110bfd6698efc7f501675bcfe0c775459a8140750eb"
+      sha256: e2eb0491ba5ddb6177742d2da23904574082139b07c1e33b8503b9f46f3e1a37
       url: "https://pub.dev"
     source: hosted
-    version: "2.13.0"
+    version: "2.13.1"
   boolean_selector:
     dependency: transitive
     description:
@@ -53,18 +53,18 @@ packages:
     dependency: transitive
     description:
       name: build
-      sha256: "275bf6bb2a00a9852c28d4e0b410da1d833a734d57d39d44f94bfc895a484ec3"
+      sha256: aadd943f4f8cc946882c954c187e6115a84c98c81ad1d9c6cbf0895a8c85da9c
       url: "https://pub.dev"
     source: hosted
-    version: "4.0.4"
+    version: "4.0.5"
   build_config:
     dependency: transitive
     description:
       name: build_config
-      sha256: "4f64382b97504dc2fcdf487d5aae33418e08b4703fc21249e4db6d804a4d0187"
+      sha256: "4070d2a59f8eec34c97c86ceb44403834899075f66e8a9d59706f8e7834f6f71"
       url: "https://pub.dev"
     source: hosted
-    version: "1.2.0"
+    version: "1.3.0"
   build_daemon:
     dependency: transitive
     description:
@@ -77,10 +77,10 @@ packages:
     dependency: "direct dev"
     description:
       name: build_runner
-      sha256: "39ad4ca8a2876779737c60e4228b4bcd35d4352ef7e14e47514093edc012c734"
+      sha256: "521daf8d189deb79ba474e43a696b41c49fb3987818dbacf3308f1e03673a75e"
       url: "https://pub.dev"
     source: hosted
-    version: "2.11.1"
+    version: "2.13.1"
   built_collection:
     dependency: transitive
     description:
@@ -93,10 +93,10 @@ packages:
     dependency: transitive
     description:
       name: built_value
-      sha256: "7931c90b84bc573fef103548e354258ae4c9d28d140e41961df6843c5d60d4d8"
+      sha256: "0730c18c770d05636a8f945c32a4d7d81cb6e0f0148c8db4ad12e7748f7e49af"
       url: "https://pub.dev"
     source: hosted
-    version: "8.12.3"
+    version: "8.12.5"
   characters:
     dependency: transitive
     description:
@@ -181,10 +181,10 @@ packages:
     dependency: transitive
     description:
       name: dart_style
-      sha256: "15a7db352c8fc6a4d2bc475ba901c25b39fe7157541da4c16eacce6f8be83e49"
+      sha256: "29f7ecc274a86d32920b1d9cfc7502fa87220da41ec60b55f329559d5732e2b2"
       url: "https://pub.dev"
     source: hosted
-    version: "3.1.5"
+    version: "3.1.7"
   dbus:
     dependency: transitive
     description:
@@ -197,26 +197,26 @@ packages:
     dependency: "direct dev"
     description:
       name: dependency_validator
-      sha256: "653cfb9927a7f4055699264c0ea934b0e9dd07760330c62ffa74861c646b98a8"
+      sha256: d6084f8df7677843c8fd0e08b66c11d9c2ce9bae1bb1f18cc574bcb28ebe71b0
       url: "https://pub.dev"
     source: hosted
-    version: "5.0.4"
+    version: "5.0.5"
   dio:
     dependency: transitive
     description:
       name: dio
-      sha256: b9d46faecab38fc8cc286f80bc4d61a3bb5d4ac49e51ed877b4d6706efe57b25
+      sha256: aff32c08f92787a557dd5c0145ac91536481831a01b4648136373cddb0e64f8c
       url: "https://pub.dev"
     source: hosted
-    version: "5.9.1"
+    version: "5.9.2"
   dio_web_adapter:
     dependency: transitive
     description:
       name: dio_web_adapter
-      sha256: "7586e476d70caecaf1686d21eee7247ea43ef5c345eab9e0cc3583ff13378d78"
+      sha256: "2f9e64323a7c3c7ef69567d5c800424a11f8337b8b228bad02524c9fb3c1f340"
       url: "https://pub.dev"
     source: hosted
-    version: "2.1.1"
+    version: "2.1.2"
   dots_indicator:
     dependency: transitive
     description:
@@ -293,10 +293,10 @@ packages:
     dependency: "direct main"
     description:
       name: fl_chart
-      sha256: "7ca9a40f4eb85949190e54087be8b4d6ac09dc4c54238d782a34cf1f7c011de9"
+      sha256: b938f77d042cbcd822936a7a359a7235bad8bd72070de1f827efc2cc297ac888
       url: "https://pub.dev"
     source: hosted
-    version: "1.1.1"
+    version: "1.2.0"
   flutter:
     dependency: "direct main"
     description: flutter
@@ -415,18 +415,18 @@ packages:
     dependency: transitive
     description:
       name: flutter_plugin_android_lifecycle
-      sha256: ee8068e0e1cd16c4a82714119918efdeed33b3ba7772c54b5d094ab53f9b7fd1
+      sha256: "38d1c268de9097ff59cf0e844ac38759fc78f76836d37edad06fa21e182055a0"
       url: "https://pub.dev"
     source: hosted
-    version: "2.0.33"
+    version: "2.0.34"
   flutter_svg:
     dependency: "direct main"
     description:
       name: flutter_svg
-      sha256: "87fbd7c534435b6c5d9d98b01e1fd527812b82e68ddd8bd35fc45ed0fa8f0a95"
+      sha256: "1ded017b39c8e15c8948ea855070a5ff8ff8b3d5e83f3446e02d6bb12add7ad9"
       url: "https://pub.dev"
     source: hosted
-    version: "2.2.3"
+    version: "2.2.4"
   flutter_test:
     dependency: "direct dev"
     description: flutter
@@ -481,10 +481,10 @@ packages:
     dependency: transitive
     description:
       name: hooks
-      sha256: "7a08a0d684cb3b8fb604b78455d5d352f502b68079f7b80b831c62220ab0a4f6"
+      sha256: e79ed1e8e1929bc6ecb6ec85f0cb519c887aa5b423705ded0d0f2d9226def388
       url: "https://pub.dev"
     source: hosted
-    version: "1.0.1"
+    version: "1.0.2"
   http:
     dependency: transitive
     description:
@@ -513,10 +513,10 @@ packages:
     dependency: transitive
     description:
       name: image
-      sha256: "492bd52f6c4fbb6ee41f781ff27765ce5f627910e1e0cbecfa3d9add5562604c"
+      sha256: f9881ff4998044947ec38d098bc7c8316ae1186fa786eddffdb867b9bc94dfce
       url: "https://pub.dev"
     source: hosted
-    version: "4.7.2"
+    version: "4.8.0"
   intl:
     dependency: "direct main"
     description:
@@ -549,14 +549,30 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.6.1"
+  jni:
+    dependency: transitive
+    description:
+      name: jni
+      sha256: c2230682d5bc2362c1c9e8d3c7f406d9cbba23ab3f2e203a025dd47e0fb2e68f
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.0.0"
+  jni_flutter:
+    dependency: transitive
+    description:
+      name: jni_flutter
+      sha256: "8b59e590786050b1cd866677dddaf76b1ade5e7bc751abe04b86e84d379d3ba6"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.0.1"
   json_annotation:
     dependency: transitive
     description:
       name: json_annotation
-      sha256: "805fa86df56383000f640384b282ce0cb8431f1a7a2396de92fb66186d8c57df"
+      sha256: cb09e7dac6210041fad964ed7fbee004f14258b4eca4040f72d1234062ace4c8
       url: "https://pub.dev"
     source: hosted
-    version: "4.10.0"
+    version: "4.11.0"
   leak_tracker:
     dependency: transitive
     description:
@@ -641,10 +657,10 @@ packages:
     dependency: transitive
     description:
       name: native_toolchain_c
-      sha256: "89e83885ba09da5fdf2cdacc8002a712ca238c28b7f717910b34bcd27b0d03ac"
+      sha256: "6ba77bb18063eebe9de401f5e6437e95e1438af0a87a3a39084fbd37c90df572"
       url: "https://pub.dev"
     source: hosted
-    version: "0.17.4"
+    version: "0.17.6"
   nested:
     dependency: transitive
     description:
@@ -673,10 +689,10 @@ packages:
     dependency: "direct main"
     description:
       name: package_info_plus
-      sha256: f69da0d3189a4b4ceaeb1a3defb0f329b3b352517f52bed4290f83d4f06bc08d
+      sha256: "468c26b4254ab01979fa5e4a98cb343ea3631b9acee6f21028997419a80e1a20"
       url: "https://pub.dev"
     source: hosted
-    version: "9.0.0"
+    version: "9.0.1"
   package_info_plus_platform_interface:
     dependency: transitive
     description:
@@ -721,10 +737,10 @@ packages:
     dependency: transitive
     description:
       name: path_provider_android
-      sha256: f2c65e21139ce2c3dad46922be8272bb5963516045659e71bb16e151c93b580e
+      sha256: "914a07484c4380e572998d30486e77e0d9cd2faec72fee268086d07bf7f302c9"
       url: "https://pub.dev"
     source: hosted
-    version: "2.2.22"
+    version: "2.3.0"
   path_provider_foundation:
     dependency: transitive
     description:
@@ -761,10 +777,10 @@ packages:
     dependency: transitive
     description:
       name: petitparser
-      sha256: "1a97266a94f7350d30ae522c0af07890c70b8e62c71e8e3920d1db4d23c057d1"
+      sha256: "91bd59303e9f769f108f8df05e371341b15d59e995e6806aefab827b58336675"
       url: "https://pub.dev"
     source: hosted
-    version: "7.0.1"
+    version: "7.0.2"
   phosphor_flutter:
     dependency: "direct main"
     description:
@@ -801,10 +817,10 @@ packages:
     dependency: transitive
     description:
       name: posix
-      sha256: "6323a5b0fa688b6a010df4905a56b00181479e6d10534cecfecede2aa55add61"
+      sha256: "185ef7606574f789b40f289c233efa52e96dead518aed988e040a10737febb07"
       url: "https://pub.dev"
     source: hosted
-    version: "6.0.3"
+    version: "6.5.0"
   provider:
     dependency: "direct main"
     description:
@@ -841,10 +857,10 @@ packages:
     dependency: "direct main"
     description:
       name: share_plus
-      sha256: "14c8860d4de93d3a7e53af51bff479598c4e999605290756bbbe45cf65b37840"
+      sha256: "223873d106614442ea6f20db5a038685cc5b32a2fba81cdecaefbbae0523f7fa"
       url: "https://pub.dev"
     source: hosted
-    version: "12.0.1"
+    version: "12.0.2"
   share_plus_platform_interface:
     dependency: transitive
     description:
@@ -857,18 +873,18 @@ packages:
     dependency: "direct main"
     description:
       name: shared_preferences
-      sha256: "2939ae520c9024cb197fc20dee269cd8cdbf564c8b5746374ec6cacdc5169e64"
+      sha256: c3025c5534b01739267eb7d76959bbc25a6d10f6988e1c2a3036940133dd10bf
       url: "https://pub.dev"
     source: hosted
-    version: "2.5.4"
+    version: "2.5.5"
   shared_preferences_android:
     dependency: transitive
     description:
       name: shared_preferences_android
-      sha256: cbc40be9be1c5af4dab4d6e0de4d5d3729e6f3d65b89d21e1815d57705644a6f
+      sha256: e8d4762b1e2e8578fc4d0fd548cebf24afd24f49719c08974df92834565e2c53
       url: "https://pub.dev"
     source: hosted
-    version: "2.4.20"
+    version: "2.4.23"
   shared_preferences_foundation:
     dependency: transitive
     description:
@@ -889,10 +905,10 @@ packages:
     dependency: transitive
     description:
       name: shared_preferences_platform_interface
-      sha256: "57cbf196c486bc2cf1f02b85784932c6094376284b3ad5779d1b1c6c6a816b80"
+      sha256: "649dc798a33931919ea356c4305c2d1f81619ea6e92244070b520187b5140ef9"
       url: "https://pub.dev"
     source: hosted
-    version: "2.4.1"
+    version: "2.4.2"
   shared_preferences_web:
     dependency: transitive
     description:
@@ -934,18 +950,18 @@ packages:
     dependency: transitive
     description:
       name: source_gen
-      sha256: "1d562a3c1f713904ebbed50d2760217fd8a51ca170ac4b05b0db490699dbac17"
+      sha256: "732792cfd197d2161a65bb029606a46e0a18ff30ef9e141a7a82172b05ea8ecd"
       url: "https://pub.dev"
     source: hosted
-    version: "4.2.0"
+    version: "4.2.2"
   source_helper:
     dependency: transitive
     description:
       name: source_helper
-      sha256: "4a85e90b50694e652075cbe4575665539d253e6ec10e46e76b45368ab5e3caae"
+      sha256: "1d3b229b2934034fb2e691fbb3d53e0f75a4af7b1407f88425ed8f209bcb1b8f"
       url: "https://pub.dev"
     source: hosted
-    version: "1.3.10"
+    version: "1.3.11"
   source_span:
     dependency: transitive
     description:
@@ -1014,10 +1030,10 @@ packages:
     dependency: "direct dev"
     description:
       name: translations_cleaner
-      sha256: "811f42be32f024fdf083903f198d3625f6ee6927601e3a53a29b85b90508b88c"
+      sha256: c6e5051cb5d4fe4c5b2cc1ef83a6964f27063f9cf5b6166f445709bea8f81ad3
       url: "https://pub.dev"
     source: hosted
-    version: "0.1.0"
+    version: "0.1.1"
   typed_data:
     dependency: transitive
     description:
@@ -1038,10 +1054,10 @@ packages:
     dependency: transitive
     description:
       name: url_launcher_android
-      sha256: "767344bf3063897b5cf0db830e94f904528e6dd50a6dfaf839f0abf509009611"
+      sha256: "3bb000251e55d4a209aa0e2e563309dc9bb2befea2295fd0cec1f51760aac572"
       url: "https://pub.dev"
     source: hosted
-    version: "6.3.28"
+    version: "6.3.29"
   url_launcher_ios:
     dependency: transitive
     description:
@@ -1094,18 +1110,18 @@ packages:
     dependency: transitive
     description:
       name: uuid
-      sha256: a11b666489b1954e01d992f3d601b1804a33937b5a8fe677bd26b8a9f96f96e8
+      sha256: "1fef9e8e11e2991bb773070d4656b7bd5d850967a2456cfc83cf47925ba79489"
       url: "https://pub.dev"
     source: hosted
-    version: "4.5.2"
+    version: "4.5.3"
   vector_graphics:
     dependency: transitive
     description:
       name: vector_graphics
-      sha256: a4f059dc26fc8295b5921376600a194c4ec7d55e72f2fe4c7d2831e103d461e6
+      sha256: "81da85e9ca8885ade47f9685b953cb098970d11be4821ac765580a6607ea4373"
       url: "https://pub.dev"
     source: hosted
-    version: "1.1.19"
+    version: "1.1.21"
   vector_graphics_codec:
     dependency: transitive
     description:
@@ -1118,10 +1134,10 @@ packages:
     dependency: transitive
     description:
       name: vector_graphics_compiler
-      sha256: "201e876b5d52753626af64b6359cd13ac6011b80728731428fd34bc840f71c9b"
+      sha256: "5a88dd14c0954a5398af544651c7fb51b457a2a556949bfb25369b210ef73a74"
       url: "https://pub.dev"
     source: hosted
-    version: "1.1.20"
+    version: "1.2.0"
   vector_math:
     dependency: transitive
     description:

--- a/app/pubspec.yaml
+++ b/app/pubspec.yaml
@@ -46,6 +46,7 @@ dependencies:
   share_plus: ^12.0.1
   url_launcher: ^6.3.2
   flutter_local_notifications: ^20.1.0
+  flutter_m3shapes_extended: ^1.1.0
   timezone: ^0.10.1
 
   # The following adds the Cupertino Icons font to your application.

--- a/app/pubspec.yaml
+++ b/app/pubspec.yaml
@@ -18,8 +18,8 @@ publish_to: 'none' # Remove this line if you wish to publish to pub.dev
 version: 0.15.1+39
 
 environment:
-  sdk: ">=3.9.0 <4.0.0"
-  flutter: ">=3.41.0"
+  sdk: ">=3.11.0 <4.0.0"
+  flutter: ">=3.41.6"
 
 dependencies:
   flutter:
@@ -28,26 +28,26 @@ dependencies:
     sdk: flutter
 
   dynamic_color: ^1.8.1
-  file_picker: ^10.3.8
+  file_picker: ^11.0.2
   file_saver: ^0.3.1
-  fl_chart: ^1.1.1
-  flutter_auto_size_text: ^4.1.0
-  flutter_svg: ^2.2.3
-  hive_ce: ^2.16.0
-  hive_ce_flutter: ^2.3.3
+  fl_chart: ^1.2.0
+  flutter_auto_size_text: ^5.0.0
+  flutter_svg: ^2.2.4
+  hive_ce: ^2.19.3
+  hive_ce_flutter: ^2.3.4
   intl: ^0.20.2
   introduction_screen: ^4.0.0
   ml_linalg: ^13.12.7
-  package_info_plus: ^9.0.0
+  package_info_plus: ^9.0.1
   path_provider: ^2.1.5
   phosphor_flutter: ^2.1.0
   provider: ^6.1.5+1
-  shared_preferences: ^2.5.4
-  share_plus: ^12.0.1
+  shared_preferences: ^2.5.5
+  share_plus: ^12.0.2
   url_launcher: ^6.3.2
-  flutter_local_notifications: ^20.1.0
+  flutter_local_notifications: ^21.0.0
   flutter_m3shapes_extended: ^1.1.0
-  timezone: ^0.10.1
+  timezone: ^0.11.0
 
   # The following adds the Cupertino Icons font to your application.
   # Use with the CupertinoIcons class for iOS style icons.
@@ -60,11 +60,11 @@ dev_dependencies:
   flutter_test:
     sdk: flutter
 
-  build_runner: ^2.7.1
-  dependency_validator: ^5.0.3
+  build_runner: ^2.13.1
+  dependency_validator: ^5.0.5
   flutter_launcher_icons: ^0.14.4
   flutter_lints: ^6.0.0
-  hive_ce_generator: ^1.10.0
+  hive_ce_generator: ^1.11.1
   translations_cleaner: ^0.1.0
 
 # define app icons


### PR DESCRIPTION
- [x] clean up interpolation API, so that stats is purely based on DateTime rather than internal indices.
- [x] add custom range selection for the stats, #416
- [x] Add selection of StatsRange
- [x] make `finalSlope` sensitive to custom range
- [x] Prepare all properties of #429
  - [x] add dailyDeficit [kcal/day]
  - [x] diff to target
- [x] Fix regression issues, fix #448 

@gwosd we were mixing in many stats using measurements, interpolation and also on different days (last measurement, today). I have switched now mainly to the interpolation, so that it is easy to implement a range selection. The only question is on how to make the selection of the StatsRange visually distinct from the colorful bento grid.