### PR TITLE
Truncate export timestamps to millisecond precision

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,9 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - Reworked the measurement list: entries are now grouped by month and can be
   filtered by year and month
 
+### Bugfix 🐛:
+- Fixed export writing microseconds in the timestamp of the latest measurement
+
 
 ## [1.2.0] - 2026-07-01
 

--- a/app/lib/core/changelog.g.dart
+++ b/app/lib/core/changelog.g.dart
@@ -14,6 +14,9 @@ const Changelog changelog = Changelog(<ChangelogEntry>[
       ChangelogSection.addedFeatures: <String>[
         'Reworked the measurement list: entries are now grouped by month and can be filtered by year and month',
       ],
+      ChangelogSection.bugfix: <String>[
+        'Fixed export writing microseconds in the timestamp of the latest measurement',
+      ],
     },
   ),
   ChangelogEntry(

--- a/app/lib/core/measurement.dart
+++ b/app/lib/core/measurement.dart
@@ -53,8 +53,17 @@ class Measurement {
   int get dateInMs => date.millisecondsSinceEpoch;
 
   /// return string for export
-  String get exportString =>
-      '${date.toIso8601String()} ${weight.toStringAsFixed(10)}';
+  ///
+  /// The date is truncated to millisecond precision so that exports always
+  /// use the same number of fractional digits.
+  String get exportString {
+    final DateTime truncatedDate = DateTime.fromMillisecondsSinceEpoch(
+      date.millisecondsSinceEpoch,
+      isUtc: date.isUtc,
+    );
+    return '${truncatedDate.toIso8601String()} '
+        '${weight.toStringAsFixed(10)}';
+  }
 
   /// Parses a [Measurement] from an [exportString] produced by [exportString].
   ///

--- a/app/test/core/measurement_test.dart
+++ b/app/test/core/measurement_test.dart
@@ -148,6 +148,14 @@ void main() {
       final List<String> parts = export.split(' ');
       expect(parts.length, 2);
     });
+
+    test('truncates microseconds to millisecond precision', () {
+      final Measurement m = Measurement(
+        weight: 73.8,
+        date: DateTime(2026, 7, 15, 12, 13, 59, 170, 608),
+      );
+      expect(m.exportString, '2026-07-15T12:13:59.170 73.8000000000');
+    });
   });
 
   group('Measurement.fromString', () {


### PR DESCRIPTION
Fixes #489 by cutting off the microseconds so every line in the backup has the same three fractional digits.