### PR TITLE
ci: build Accrescent APK set and attach it to releases

### DIFF
--- a/.github/workflows/flutter-release.yml
+++ b/.github/workflows/flutter-release.yml
@@ -9,7 +9,8 @@ permissions:
   
 jobs:
   deployAndroid:
-    permissions: write-all
+    permissions:
+      contents: write
     name: Build & deploy Android release
     runs-on: ubuntu-latest
     steps:
@@ -34,6 +35,13 @@ jobs:
           channel: 'stable'
           cache: true
         id: flutter
+      - name: ⚙️ Setup bundletool
+        env:
+          BUNDLETOOL_VERSION: "1.18.3"
+        run: |
+          curl -fsSL -o "${{ github.workspace }}/bundletool.jar" \
+            "https://github.com/google/bundletool/releases/download/${BUNDLETOOL_VERSION}/bundletool-all-${BUNDLETOOL_VERSION}.jar"
+          echo "BUNDLETOOL=java -jar ${{ github.workspace }}/bundletool.jar" >> "$GITHUB_ENV"
       - name: 🔐 Retrieve base64 keystore and decode it to a file
         id: write_file
         uses: timheuer/base64-to-file@v2.0
@@ -58,9 +66,9 @@ jobs:
         run: |
           cd app
           make build
-          make build-aab
+          make build-apks
       - name: 🤖🚀 Upload to GitHub release
         uses: AButler/upload-release-assets@v4.0.0
         with:
-          files: 'app/build/app/outputs/flutter-apk/*;app/build/app/outputs/bundle/release/*'
+          files: 'app/build/app/outputs/flutter-apk/*;app/build/app/outputs/bundle/release/*;app/build/app/outputs/apks/*'
           repo-token: ${{ secrets.GITHUB_TOKEN }}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -22,6 +22,7 @@ make generate        # changelog.g.dart from ../CHANGELOG.md
 | Changelog check (as CI) | `dart run quantumphysique:generate_changelog --check` |
 | Hive adapters | `make hive` (after editing `measurement.dart`) |
 | Release APK | `make build` |
+| Accrescent APK set | `make build-apks` (needs bundletool + `android/key.properties`) |
 
 **Format, analyze and test once, on the finished change.** They are the gate before commit and PR, not a step after every edit. In between, run only what answers a concrete question — one test file, usually.
 
@@ -31,7 +32,7 @@ CI (`build-flutter.yml`) runs `dart format --set-exit-if-changed`, `dart analyze
 
 - `main` is the only long-lived branch; feature branches `feat/<topic>`, `fix/<topic>`, `ci/<topic>`, `chore/<topic>` off `main`, back by merge commit. Never commit to `main` directly.
 - Every commit lands on `main` as it is (no squash), so every commit is a conventional commit — see `/commit`. The PR title uses the same format.
-- Versions are hand-made: a `release/prepare_vX.Y.Z` branch with one `chore: prepare vX.Y.Z` commit that turns `[Unreleased]` in `CHANGELOG.md` into `[X.Y.Z] - <date>`, bumps `version:` in `pubspec.yaml` (name and build number), adds `fastlane/metadata/android/{en-US,de}/changelogs/<build>3.txt` (build number followed by the arm64 ABI digit) and regenerates `changelog.g.dart`. Only after merge: a GitHub release tagged `vX.Y.Z` with the changelog section as body; `flutter-release.yml` builds and uploads the APKs. Never create tags by hand.
+- Versions are hand-made: a `release/prepare_vX.Y.Z` branch with one `chore: prepare vX.Y.Z` commit that turns `[Unreleased]` in `CHANGELOG.md` into `[X.Y.Z] - <date>`, bumps `version:` in `pubspec.yaml` (name and build number), adds `fastlane/metadata/android/{en-US,de}/changelogs/<build>3.txt` (build number followed by the arm64 ABI digit) and regenerates `changelog.g.dart`. Only after merge: a GitHub release tagged `vX.Y.Z` with the changelog section as body; `flutter-release.yml` builds and uploads the APKs, the AAB and the Accrescent `.apks`. Never create tags by hand.
 
 ## Changelog
 

--- a/app/Makefile
+++ b/app/Makefile
@@ -42,6 +42,32 @@ build: $(CHANGELOG_GEN)
 build-aab: $(CHANGELOG_GEN)
 	flutter build appbundle --release
 
+# Override for a jar: BUNDLETOOL="java -jar /path/to/bundletool-all.jar"
+BUNDLETOOL ?= bundletool
+KEY_PROPERTIES := android/key.properties
+APP_VERSION := $(shell sed -n -E 's/^version: ([0-9.]+)\+.*/\1/p' pubspec.yaml)
+AAB := build/app/outputs/bundle/release/app-release.aab
+APKS_DIR := build/app/outputs/apks
+APKS := $(APKS_DIR)/trale-$(APP_VERSION).apks
+
+## Build the APK set (.apks) for Accrescent from the signed release bundle.
+## Needs bundletool and android/key.properties. Recipe is silenced so the
+## keystore passwords never reach the terminal or CI log.
+.PHONY: build-apks
+build-apks: build-aab
+	@mkdir -p $(APKS_DIR)
+	@KS=$$(sed -n 's/^storeFile=//p' $(KEY_PROPERTIES)); \
+	case "$$KS" in /*) ;; *) KS="android/$$KS";; esac; \
+	echo "$(BUNDLETOOL) build-apks --bundle=$(AAB) --output=$(APKS)"; \
+	$(BUNDLETOOL) build-apks \
+		--bundle=$(AAB) \
+		--output=$(APKS) \
+		--overwrite \
+		--ks="$$KS" \
+		--ks-key-alias="$$(sed -n 's/^keyAlias=//p' $(KEY_PROPERTIES))" \
+		--ks-pass="pass:$$(sed -n 's/^storePassword=//p' $(KEY_PROPERTIES))" \
+		--key-pass="pass:$$(sed -n 's/^keyPassword=//p' $(KEY_PROPERTIES))"
+
 .PHONY: analyze
 analyze: $(CHANGELOG_GEN)
 	flutter analyze
@@ -99,6 +125,7 @@ help:
 	@echo "  make run        – generate + flutter run"
 	@echo "  make build      – generate + flutter build apk"
 	@echo "  make build-aab  – generate + flutter build appbundle"
+	@echo "  make build-apks – build-aab + bundletool APK set for Accrescent"
 	@echo "  make analyze    – generate + flutter analyze"
 	@echo "  make test       – generate + flutter test"
 	@echo "  make coverage   – generate + flutter test --coverage"

--- a/app/README.md
+++ b/app/README.md
@@ -44,8 +44,12 @@ dart run dart_code_metrics:metrics check-unused-l10n lib
 dart run dart_code_metrics:metrics check-unused-code lib
 ```
 
-### Generate APKS
+### Generate APK set for Accrescent
+Needs `bundletool` (`brew install bundletool`, or
+`BUNDLETOOL="java -jar /path/to/bundletool-all.jar"`) and `android/key.properties`.
 ```bash
-traleVersion="0.11.1"
-bundletool build-apks --bundle trale-${traleVersion}.aab --output trale-${traleVersion}.apks --ks ~/path/to/key.jks --ks-key-alias=key
+make build-apks
+# -> build/app/outputs/apks/trale-<version>.apks
 ```
+The release workflow runs the same target and attaches the `.apks` to the
+GitHub release.


### PR DESCRIPTION
The `.apks` for Accrescent was produced by hand with bundletool after each release. The release workflow now downloads bundletool 1.18.3, runs the new `make build-apks` target (bundletool over the signed AAB, keystore from `android/key.properties`) and uploads the result next to the APKs and AAB.

Also narrows the release job from `permissions: write-all` to `contents: write`, which is all the asset upload needs.

Not tested end-to-end: a real run needs the release keystore, so the next published (pre-)release is the first full check. `make -n build-apks` expands as expected and the YAML parses.
