### PR TITLE
fix: keep app-specific wording out of the shared qp_ strings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,10 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - The Health Connect import now says why nothing arrived instead of reporting
   "Imported 0 measurements" for a missing permission or a failed read
 
+### Other Changes:
+- The translation banner and the reminder settings now reuse the wording trale
+  already had, dropping a second, near-identical copy of both sentences
+
 
 ## [1.3.1] - 2026-08-31
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -64,6 +64,7 @@ Released state is different: Hive fields, preference keys and the backup format 
 - Types everywhere (`always_specify_types`); `const` where possible; single quotes; 80 columns
 - Theme only through `QPTheme.of(context)` and `Theme.of(context)` — no literal colours, sizes or radii
 - Strings only through `context.l10n`; new keys go in `app_en.arb` and `app_de.arb`. The other languages come from Weblate — never edit them by hand
+- `qp_*` keys are the vocabulary shared with the other quantumphysique apps, which copy them over verbatim, so they must never name trale or weight tracking. A `QPStrings` field that does (`translateSubtitle`, `reminderSubtitle`) is fed from an app-owned key in `l10n_extension.dart`; `test/core/qp_strings_test.dart` enforces it
 - Enums carry behaviour in extensions (see `units.dart`)
 - Constants in `lib/core/constants.dart` (`dayInMs`, `kcalPerKg`), no magic numbers
 - Adding a setting: getter/setter in the matching `preferences/*.dart` part, default in `loadDefaultSettings()`, property plus `notifyListeners()` in the matching `trale_notifier/*.dart` part

--- a/app/lib/core/changelog.g.dart
+++ b/app/lib/core/changelog.g.dart
@@ -18,6 +18,9 @@ const Changelog changelog = Changelog(<ChangelogEntry>[
         'Fixed the Health Connect history import reaching no further back than 30 days: Health Connect hides older records until an app asks for access to past data, which trale now does when the import is switched on and when the full history is requested',
         'The Health Connect import now says why nothing arrived instead of reporting "Imported 0 measurements" for a missing permission or a failed read',
       ],
+      ChangelogSection.otherChanges: <String>[
+        'The translation banner and the reminder settings now reuse the wording trale already had, dropping a second, near-identical copy of both sentences',
+      ],
     },
   ),
   ChangelogEntry(

--- a/app/lib/core/l10n_extension.dart
+++ b/app/lib/core/l10n_extension.dart
@@ -16,12 +16,16 @@ extension AppLocalizationsX on BuildContext {
 /// Builds a [QPStrings] instance from [AppLocalizations].
 ///
 /// Call this wherever you need to pass [QPStrings] to a QP widget or page.
+///
+/// The `qp_` keys mirror the package's shared vocabulary and are copied
+/// verbatim into the other QP apps, so the two that name trale or weight
+/// tracking come from app-owned keys instead.
 QPStrings qpStringsFromL10n(AppLocalizations l) => QPStrings(
   defaultLangLabel: l.qp_defaultLangLabel,
   language: l.qp_language,
   languageSubtitle: l.qp_languageSubtitle,
   translate: l.qp_translate,
-  translateSubtitle: l.qp_translateSubtitle,
+  translateSubtitle: l.translateSubtitle,
   theme: l.qp_theme,
   themeSubtitle: l.qp_themeSubtitle,
   darkMode: l.qp_darkMode,
@@ -34,7 +38,7 @@ QPStrings qpStringsFromL10n(AppLocalizations l) => QPStrings(
   themePalette: l.qp_themePalette,
   schemeVariant: l.qp_schemeVariant,
   reminderTitle: l.qp_reminderTitle,
-  reminderSubtitle: l.qp_reminderSubtitle,
+  reminderSubtitle: l.reminderSubtitle,
   reminderEnabled: l.qp_reminderEnabled,
   reminderDays: l.qp_reminderDays,
   reminderTime: l.qp_reminderTime,

--- a/app/lib/l10n/app_de.arb
+++ b/app/lib/l10n/app_de.arb
@@ -603,10 +603,6 @@
     "@qp_translate": {
         "description": "Banner title prompting users to help translate the app"
     },
-    "qp_translateSubtitle": "Hilf uns, trale in weitere Sprachen zu übersetzen",
-    "@qp_translateSubtitle": {
-        "description": "Banner subtitle for translation call-to-action"
-    },
     "qp_theme": "Design",
     "@qp_theme": {
         "description": "Theme settings title"
@@ -654,10 +650,6 @@
     "qp_reminderTitle": "Erinnerungen",
     "@qp_reminderTitle": {
         "description": "Reminder settings title"
-    },
-    "qp_reminderSubtitle": "Tägliche Wiege-Erinnerungen",
-    "@qp_reminderSubtitle": {
-        "description": "Reminder settings subtitle shown in the overview"
     },
     "qp_reminderEnabled": "Erinnerungen einschalten",
     "@qp_reminderEnabled": {

--- a/app/lib/l10n/app_en.arb
+++ b/app/lib/l10n/app_en.arb
@@ -863,10 +863,6 @@
     "@qp_translate": {
         "description": "Banner title prompting users to help translate the app"
     },
-    "qp_translateSubtitle": "Help us translate trale into more languages",
-    "@qp_translateSubtitle": {
-        "description": "Banner subtitle for translation call-to-action"
-    },
     "qp_theme": "Theme",
     "@qp_theme": {
         "description": "Theme settings title"
@@ -914,10 +910,6 @@
     "qp_reminderTitle": "Reminders",
     "@qp_reminderTitle": {
         "description": "Reminder settings title"
-    },
-    "qp_reminderSubtitle": "Daily weight-logging reminders",
-    "@qp_reminderSubtitle": {
-        "description": "Reminder settings subtitle shown in the overview"
     },
     "qp_reminderEnabled": "Enable reminders",
     "@qp_reminderEnabled": {

--- a/app/lib/l10n/app_es.arb
+++ b/app/lib/l10n/app_es.arb
@@ -853,10 +853,6 @@
     "@qp_translate": {
         "description": "Banner title prompting users to help translate the app"
     },
-    "qp_translateSubtitle": "Ayúdanos a traducir trale a más idiomas",
-    "@qp_translateSubtitle": {
-        "description": "Banner subtitle for translation call-to-action"
-    },
     "qp_theme": "Tema",
     "@qp_theme": {
         "description": "Theme settings title"
@@ -904,10 +900,6 @@
     "qp_reminderTitle": "Recordatorios",
     "@qp_reminderTitle": {
         "description": "Reminder settings title"
-    },
-    "qp_reminderSubtitle": "Recordatorios diarios para registrar el peso",
-    "@qp_reminderSubtitle": {
-        "description": "Reminder settings subtitle shown in the overview"
     },
     "qp_reminderEnabled": "Activar recordatorios",
     "@qp_reminderEnabled": {

--- a/app/lib/l10n/app_et.arb
+++ b/app/lib/l10n/app_et.arb
@@ -853,10 +853,6 @@
     "@qp_translate": {
         "description": "Banner title prompting users to help translate the app"
     },
-    "qp_translateSubtitle": "Aita rakendust tõlkida muudesse keeltesse",
-    "@qp_translateSubtitle": {
-        "description": "Banner subtitle for translation call-to-action"
-    },
     "qp_theme": "Kujundus",
     "@qp_theme": {
         "description": "Theme settings title"
@@ -904,10 +900,6 @@
     "qp_reminderTitle": "Meeldetuletused",
     "@qp_reminderTitle": {
         "description": "Reminder settings title"
-    },
-    "qp_reminderSubtitle": "Igapäevased kaalumõõtmise meeldetuletused",
-    "@qp_reminderSubtitle": {
-        "description": "Reminder settings subtitle shown in the overview"
     },
     "qp_reminderEnabled": "Kasuta meeldetuletusi",
     "@qp_reminderEnabled": {

--- a/app/lib/l10n/app_fi.arb
+++ b/app/lib/l10n/app_fi.arb
@@ -853,10 +853,6 @@
     "@qp_translate": {
         "description": "Banner title prompting users to help translate the app"
     },
-    "qp_translateSubtitle": "Auta meitä kääntämään trale useammalle kielelle",
-    "@qp_translateSubtitle": {
-        "description": "Banner subtitle for translation call-to-action"
-    },
     "qp_theme": "Teema",
     "@qp_theme": {
         "description": "Theme settings title"
@@ -904,10 +900,6 @@
     "qp_reminderTitle": "Muistutukset",
     "@qp_reminderTitle": {
         "description": "Reminder settings title"
-    },
-    "qp_reminderSubtitle": "Päivittäiset painonkirjausmuistutukset",
-    "@qp_reminderSubtitle": {
-        "description": "Reminder settings subtitle shown in the overview"
     },
     "qp_reminderEnabled": "Laita päälle muistutukset",
     "@qp_reminderEnabled": {

--- a/app/lib/l10n/app_fr.arb
+++ b/app/lib/l10n/app_fr.arb
@@ -811,10 +811,6 @@
     "@qp_translate": {
         "description": "Banner title prompting users to help translate the app"
     },
-    "qp_translateSubtitle": "Aidez-nous à traduire trale dans d'autres langues",
-    "@qp_translateSubtitle": {
-        "description": "Banner subtitle for translation call-to-action"
-    },
     "qp_theme": "Thème",
     "@qp_theme": {
         "description": "Theme settings title"
@@ -924,10 +920,6 @@
     "qp_schemeVariant": "Variante du schéma de couleurs",
     "@qp_schemeVariant": {
         "description": "Scheme variant selection section title"
-    },
-    "qp_reminderSubtitle": "Rappels quotidiens de pesée",
-    "@qp_reminderSubtitle": {
-        "description": "Reminder settings subtitle shown in the overview"
     },
     "qp_firstDayDefault": "Par défaut (régional)",
     "@qp_firstDayDefault": {

--- a/app/lib/l10n/app_it.arb
+++ b/app/lib/l10n/app_it.arb
@@ -853,10 +853,6 @@
     "@qp_translate": {
         "description": "Banner title prompting users to help translate the app"
     },
-    "qp_translateSubtitle": "Aiutaci a tradurre trale in più lingue",
-    "@qp_translateSubtitle": {
-        "description": "Banner subtitle for translation call-to-action"
-    },
     "qp_theme": "Tema",
     "@qp_theme": {
         "description": "Theme settings title"
@@ -904,10 +900,6 @@
     "qp_reminderTitle": "Promemoria",
     "@qp_reminderTitle": {
         "description": "Reminder settings title"
-    },
-    "qp_reminderSubtitle": "Promemoria giornalieri per registrare il peso",
-    "@qp_reminderSubtitle": {
-        "description": "Reminder settings subtitle shown in the overview"
     },
     "qp_reminderEnabled": "Attiva promemoria",
     "@qp_reminderEnabled": {

--- a/app/lib/l10n/app_nl.arb
+++ b/app/lib/l10n/app_nl.arb
@@ -853,10 +853,6 @@
     "@qp_translate": {
         "description": "Banner title prompting users to help translate the app"
     },
-    "qp_translateSubtitle": "Help ons trale in meer talen te vertalen",
-    "@qp_translateSubtitle": {
-        "description": "Banner subtitle for translation call-to-action"
-    },
     "qp_theme": "Thema",
     "@qp_theme": {
         "description": "Theme settings title"
@@ -904,10 +900,6 @@
     "qp_reminderTitle": "Herinneringen",
     "@qp_reminderTitle": {
         "description": "Reminder settings title"
-    },
-    "qp_reminderSubtitle": "Dagelijkse herinneringen om je gewicht te noteren",
-    "@qp_reminderSubtitle": {
-        "description": "Reminder settings subtitle shown in the overview"
     },
     "qp_reminderEnabled": "Herinneringen inschakelen",
     "@qp_reminderEnabled": {

--- a/app/lib/l10n/app_pl.arb
+++ b/app/lib/l10n/app_pl.arb
@@ -853,10 +853,6 @@
     "@qp_translate": {
         "description": "Banner title prompting users to help translate the app"
     },
-    "qp_translateSubtitle": "Pomóż nam przetłumaczyć trale na więcej języków",
-    "@qp_translateSubtitle": {
-        "description": "Banner subtitle for translation call-to-action"
-    },
     "qp_theme": "Motyw",
     "@qp_theme": {
         "description": "Theme settings title"
@@ -904,10 +900,6 @@
     "qp_reminderTitle": "Przypomnienia",
     "@qp_reminderTitle": {
         "description": "Reminder settings title"
-    },
-    "qp_reminderSubtitle": "Codzienne przypomnienia o zapisywaniu wagi",
-    "@qp_reminderSubtitle": {
-        "description": "Reminder settings subtitle shown in the overview"
     },
     "qp_reminderEnabled": "Włącz przypomnienia",
     "@qp_reminderEnabled": {

--- a/app/lib/l10n/app_pt.arb
+++ b/app/lib/l10n/app_pt.arb
@@ -853,10 +853,6 @@
     "@qp_translate": {
         "description": "Banner title prompting users to help translate the app"
     },
-    "qp_translateSubtitle": "Ajude-nos a traduzir o trale para mais idiomas",
-    "@qp_translateSubtitle": {
-        "description": "Banner subtitle for translation call-to-action"
-    },
     "qp_theme": "Tema",
     "@qp_theme": {
         "description": "Theme settings title"
@@ -904,10 +900,6 @@
     "qp_reminderTitle": "Lembretes",
     "@qp_reminderTitle": {
         "description": "Reminder settings title"
-    },
-    "qp_reminderSubtitle": "Lembretes diários para registrar o peso",
-    "@qp_reminderSubtitle": {
-        "description": "Reminder settings subtitle shown in the overview"
     },
     "qp_reminderEnabled": "Ativar lembretes",
     "@qp_reminderEnabled": {

--- a/app/lib/l10n/app_ru.arb
+++ b/app/lib/l10n/app_ru.arb
@@ -853,10 +853,6 @@
     "@qp_translate": {
         "description": "Banner title prompting users to help translate the app"
     },
-    "qp_translateSubtitle": "Помогите нам перевести trale на другие языки",
-    "@qp_translateSubtitle": {
-        "description": "Banner subtitle for translation call-to-action"
-    },
     "qp_theme": "Тема",
     "@qp_theme": {
         "description": "Theme settings title"
@@ -904,10 +900,6 @@
     "qp_reminderTitle": "Напоминания",
     "@qp_reminderTitle": {
         "description": "Reminder settings title"
-    },
-    "qp_reminderSubtitle": "Ежедневные напоминания о записи веса",
-    "@qp_reminderSubtitle": {
-        "description": "Reminder settings subtitle shown in the overview"
     },
     "qp_reminderEnabled": "Включить напоминания",
     "@qp_reminderEnabled": {

--- a/app/lib/l10n/app_sq.arb
+++ b/app/lib/l10n/app_sq.arb
@@ -849,10 +849,6 @@
     "@qp_translate": {
         "description": "Banner title prompting users to help translate the app"
     },
-    "qp_translateSubtitle": "Na ndihmoni të përkthejmë trale në më shumë gjuhë",
-    "@qp_translateSubtitle": {
-        "description": "Banner subtitle for translation call-to-action"
-    },
     "qp_theme": "Tema",
     "@qp_theme": {
         "description": "Theme settings title"
@@ -900,10 +896,6 @@
     "qp_reminderTitle": "Kujtesa",
     "@qp_reminderTitle": {
         "description": "Reminder settings title"
-    },
-    "qp_reminderSubtitle": "Kujtesa për regjistrimin e peshës çdo ditë",
-    "@qp_reminderSubtitle": {
-        "description": "Reminder settings subtitle shown in the overview"
     },
     "qp_reminderEnabled": "Aktivizo rikujtuesit",
     "@qp_reminderEnabled": {

--- a/app/lib/l10n/app_zh.arb
+++ b/app/lib/l10n/app_zh.arb
@@ -849,10 +849,6 @@
     "@qp_translate": {
         "description": "Banner title prompting users to help translate the app"
     },
-    "qp_translateSubtitle": "帮助我们将 trale 翻译成更多语言",
-    "@qp_translateSubtitle": {
-        "description": "Banner subtitle for translation call-to-action"
-    },
     "qp_theme": "主题",
     "@qp_theme": {
         "description": "Theme settings title"
@@ -900,10 +896,6 @@
     "qp_reminderTitle": "提醒",
     "@qp_reminderTitle": {
         "description": "Reminder settings title"
-    },
-    "qp_reminderSubtitle": "每日体重记录提醒",
-    "@qp_reminderSubtitle": {
-        "description": "Reminder settings subtitle shown in the overview"
     },
     "qp_reminderEnabled": "开启提醒",
     "@qp_reminderEnabled": {

--- a/app/lib/l10n/app_zh_Hant.arb
+++ b/app/lib/l10n/app_zh_Hant.arb
@@ -853,10 +853,6 @@
     "@qp_translate": {
         "description": "Banner title prompting users to help translate the app"
     },
-    "qp_translateSubtitle": "協助我們將 trale 翻譯成更多語言",
-    "@qp_translateSubtitle": {
-        "description": "Banner subtitle for translation call-to-action"
-    },
     "qp_theme": "主題",
     "@qp_theme": {
         "description": "Theme settings title"
@@ -904,10 +900,6 @@
     "qp_reminderTitle": "提醒",
     "@qp_reminderTitle": {
         "description": "Reminder settings title"
-    },
-    "qp_reminderSubtitle": "每日記錄體重提醒",
-    "@qp_reminderSubtitle": {
-        "description": "Reminder settings subtitle shown in the overview"
     },
     "qp_reminderEnabled": "啟用提醒",
     "@qp_reminderEnabled": {

--- a/app/test/core/qp_strings_test.dart
+++ b/app/test/core/qp_strings_test.dart
@@ -1,0 +1,51 @@
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+
+/// Words that make a string about trale rather than about any QP app.
+const List<String> appSpecificWords = <String>['trale', 'weight', 'gewicht'];
+
+void main() {
+  group('qp_ vocabulary', () {
+    // The qp_ keys are the strings the quantumphysique package shares between
+    // apps, and adonify copies them over verbatim. One that names trale or
+    // weight tracking therefore ships as-is in an app about something else —
+    // it belongs in an app-owned key handed to QPStrings instead.
+    test('holds nothing app-specific', () {
+      final List<String> offenders = <String>[];
+
+      for (final File arb in arbFiles()) {
+        final Map<String, dynamic> strings =
+            jsonDecode(arb.readAsStringSync()) as Map<String, dynamic>;
+        strings.forEach((String key, dynamic value) {
+          if (!key.startsWith('qp_') || value is! String) {
+            return;
+          }
+          final String text = value.toLowerCase();
+          for (final String word in appSpecificWords) {
+            if (RegExp('\\b$word').hasMatch(text)) {
+              offenders.add('${arb.uri.pathSegments.last}: $key = "$value"');
+            }
+          }
+        });
+      }
+
+      expect(
+        offenders,
+        isEmpty,
+        reason:
+            'Move these to an app-owned key and pass it to QPStrings in '
+            'lib/core/l10n_extension.dart, as translateSubtitle and '
+            'reminderSubtitle already are.',
+      );
+    });
+  });
+}
+
+/// Every ARB file of the app, read straight from disk.
+List<File> arbFiles() => Directory('lib/l10n')
+    .listSync()
+    .whereType<File>()
+    .where((File f) => f.path.endsWith('.arb'))
+    .toList();

--- a/quantumphysique/lib/src/types/strings.dart
+++ b/quantumphysique/lib/src/types/strings.dart
@@ -10,6 +10,10 @@ import 'package:flutter/foundation.dart';
 /// itself — the caller is responsible for rebuilding this object when the
 /// locale changes.
 ///
+/// Most fields are app-agnostic and the apps share their translations under
+/// a `qp_` key prefix.  [translateSubtitle] and [reminderSubtitle] are not:
+/// they describe the app itself, so each app owns and translates its own.
+///
 /// ```dart
 /// QPStrings qpStringsFromL10n(AppLocalizations l) => QPStrings(
 ///   defaultLangLabel: l.qpDefaultLangLabel,
@@ -73,6 +77,9 @@ class QPStrings {
   final String translate;
 
   /// Settings tile subtitle for translation call-to-action.
+  ///
+  /// App-specific: it describes the app being translated, so it must come
+  /// from an app-owned key and never from the shared `qp_` vocabulary.
   final String translateSubtitle;
 
   // ── Theme ─────────────────────────────────────────────────────────────────
@@ -116,6 +123,9 @@ class QPStrings {
   final String reminderTitle;
 
   /// Settings section subtitle for reminders.
+  ///
+  /// App-specific: it names what the app reminds about, so it must come from
+  /// an app-owned key and never from the shared `qp_` vocabulary.
   final String reminderSubtitle;
 
   /// Settings tile title for enable-reminders toggle.


### PR DESCRIPTION
The `qp_*` keys are the vocabulary the quantumphysique package shares between apps, and adonify copies them over verbatim. Two of them were about trale rather than about any QP app:

| key | value |
|---|---|
| `qp_translateSubtitle` | "Help us translate **trale** into more languages" |
| `qp_reminderSubtitle` | "Daily **weight-logging** reminders" |

So adonify shipped both sentences as they are — a workout tracker asking to translate trale.

`QPStrings` already takes every string as a constructor argument, so nothing in the package's API had to change. Both offenders turned out to have an app-owned twin (`translateSubtitle`, `reminderSubtitle`) with exactly the same locale coverage, so `qpStringsFromL10n` now reads those and the `qp_` copies are gone. No translation is lost.

Two subtitles change wording for trale users: "Help us translate trale into more languages" → "Help translate the app" (the banner title already appends the app name), and "Daily weight-logging reminders" → "Remind yourself to log your weight".

`test/core/qp_strings_test.dart` fails if a `qp_*` value in any ARB names trale or weight again, and CLAUDE.md records the rule.